### PR TITLE
Default missing sync control record to queued

### DIFF
--- a/components/cache-db/src/main/kotlin/org/veupathdb/vdi/lib/db/cache/sql/select/select-user-dataset.kt
+++ b/components/cache-db/src/main/kotlin/org/veupathdb/vdi/lib/db/cache/sql/select/select-user-dataset.kt
@@ -33,7 +33,7 @@ FROM
   vdi.datasets vd
   INNER JOIN vdi.dataset_metadata dm
     USING (dataset_id)
-  INNER JOIN vdi.import_control ic
+  LEFT JOIN vdi.import_control ic
     USING (dataset_id)
 WHERE
   vd.dataset_id = ?
@@ -72,7 +72,7 @@ internal fun Connection.selectDatasetForUser(userID: UserID, datasetID: DatasetI
           getUserID("owner_id"),
           getBoolean("is_deleted"),
           getDateTime("created"),
-          DatasetImportStatus.fromString(getString("status")),
+          getString("status")?.let(DatasetImportStatus::fromString) ?: DatasetImportStatus.Queued,
           getString("name"),
           getString("summary"),
           getString("description"),


### PR DESCRIPTION
If a job does not yet have sync control record in the cache DB, default the sync status to queued.

This is for the case where there is a queue backup on importing datasets so we don't get a 404 when looking up the status of a dataset we just posted.

Resolves #44 