### PR TITLE
Add admin auth to target endpoints

### DIFF
--- a/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/Resources.kt
+++ b/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/Resources.kt
@@ -3,10 +3,11 @@ package org.veupathdb.service.vdi
 import org.veupathdb.lib.container.jaxrs.server.ContainerResources
 import org.veupathdb.service.vdi.config.Options
 import org.veupathdb.service.vdi.server.controllers.*
+import org.veupathdb.service.vdi.server.middleware.AuthFilter
 
 class Resources(opts: Options) : ContainerResources(opts) {
   init {
-    enableAuth()
+    registerInstances(AuthFilter(opts))
   }
 
   override fun resources() = arrayOf<Any>(

--- a/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/server/controllers/ControllerBase.kt
+++ b/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/server/controllers/ControllerBase.kt
@@ -2,12 +2,17 @@ package org.veupathdb.service.vdi.server.controllers
 
 import jakarta.ws.rs.NotFoundException
 import org.glassfish.jersey.server.ContainerRequest
+import org.veupathdb.lib.container.jaxrs.model.User
 import org.veupathdb.lib.container.jaxrs.providers.UserProvider
 import org.veupathdb.vdi.lib.common.field.DatasetID
 
 sealed class ControllerBase(protected val request: ContainerRequest) {
 
-  protected val user by lazy { UserProvider.lookupUser(request).orElseThrow() }
+  protected val maybeUser: User? by lazy { UserProvider.lookupUser(request).orElse(null) }
+
+  protected val maybeUserID get() = maybeUser?.userID
+
+  protected val user: User by lazy { UserProvider.lookupUser(request).orElseThrow() }
 
   protected val userID get() = user.userID
 

--- a/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/server/controllers/VDIDatasetByIDEndpointsController.kt
+++ b/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/server/controllers/VDIDatasetByIDEndpointsController.kt
@@ -5,17 +5,25 @@ import org.glassfish.jersey.server.ContainerRequest
 import org.veupathdb.lib.container.jaxrs.server.annotations.Authenticated
 import org.veupathdb.service.vdi.generated.model.DatasetPatchRequest
 import org.veupathdb.service.vdi.generated.resources.VdiDatasetsVdId
+import org.veupathdb.service.vdi.server.middleware.AuthFilter
 import org.veupathdb.service.vdi.service.datasets.deleteDataset
 import org.veupathdb.service.vdi.service.datasets.getDatasetByID
+import org.veupathdb.service.vdi.service.datasets.adminGetDatasetByID
 import org.veupathdb.service.vdi.service.datasets.updateDatasetMeta
 import org.veupathdb.vdi.lib.common.field.toUserID
 
 @Authenticated(allowGuests = false)
 class VDIDatasetByIDEndpointsController(@Context request: ContainerRequest) : VdiDatasetsVdId, ControllerBase(request) {
 
-  override fun getVdiDatasetsByVdId(vdID: String): VdiDatasetsVdId.GetVdiDatasetsByVdIdResponse =
-    VdiDatasetsVdId.GetVdiDatasetsByVdIdResponse
+  @AuthFilter.AllowAdminAuth
+  override fun getVdiDatasetsByVdId(vdID: String): VdiDatasetsVdId.GetVdiDatasetsByVdIdResponse {
+    val userID = maybeUserID
+      ?: return VdiDatasetsVdId.GetVdiDatasetsByVdIdResponse
+        .respond200WithApplicationJson(adminGetDatasetByID(vdID.asVDIID()))
+
+    return VdiDatasetsVdId.GetVdiDatasetsByVdIdResponse
       .respond200WithApplicationJson(getDatasetByID(userID.toUserID(), vdID.asVDIID()))
+  }
 
   override fun patchVdiDatasetsByVdId(vdID: String, entity: DatasetPatchRequest): VdiDatasetsVdId.PatchVdiDatasetsByVdIdResponse {
     updateDatasetMeta(userID.toUserID(), vdID.asVDIID(), entity)

--- a/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/server/middleware/AuthFilter.kt
+++ b/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/server/middleware/AuthFilter.kt
@@ -1,0 +1,40 @@
+package org.veupathdb.service.vdi.server.middleware
+
+import jakarta.ws.rs.container.ContainerRequestContext
+import jakarta.ws.rs.container.ResourceInfo
+import jakarta.ws.rs.core.Context
+import org.veupathdb.lib.container.jaxrs.config.Options
+import org.veupathdb.lib.container.jaxrs.server.middleware.AuthFilter
+import org.veupathdb.service.vdi.config.Options as StaticOpts
+
+class AuthFilter(private val opts: Options) : AuthFilter(opts) {
+
+  @Context
+  private var resource: ResourceInfo? = null
+
+  override fun filter(req: ContainerRequestContext) {
+    if ("Auth-Key" in req.headers) {
+      if (StaticOpts.Admin.secretKey == req.headers["Auth-Key"]!![0]) {
+        if (haveAdminAuthAnnotation()) {
+          return
+        }
+      }
+    }
+
+    super.filter(req)
+  }
+
+  fun haveAdminAuthAnnotation(): Boolean {
+    val res = resource!!
+
+    res.resourceMethod.declaredAnnotations
+      .find { it is AllowAdminAuth }
+      ?: return false
+
+    return true
+  }
+
+  @Target(AnnotationTarget.FUNCTION)
+  @Retention(AnnotationRetention.RUNTIME)
+  annotation class AllowAdminAuth
+}

--- a/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/service/shares/put-share-offer.kt
+++ b/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/service/shares/put-share-offer.kt
@@ -15,6 +15,24 @@ import org.veupathdb.vdi.lib.common.model.VDIShareReceiptAction
 import org.veupathdb.vdi.lib.db.cache.CacheDB
 import org.veupathdb.vdi.lib.db.cache.model.DatasetImportStatus
 
+internal fun adminPutShareOffer(datasetID: DatasetID, recipientID: UserID, entity: DatasetShareOffer) {
+  val dataset = CacheDB.selectDataset(datasetID) ?: throw NotFoundException()
+
+  // If the dataset has been deleted, then it isn't sharable, throw a 403.
+  if (dataset.isDeleted)
+    throw ForbiddenException("cannot share a deleted dataset")
+
+  if (dataset.importStatus != DatasetImportStatus.Complete)
+    throw ForbiddenException("cannot share a dataset until after it has been processed")
+
+  // Write or overwrite the share offer object.
+  DatasetStore.putShareOffer(dataset.ownerID, datasetID, recipientID, entity.toInternal())
+
+  // We automatically accept share offers on behalf of the recipient user.  The
+  // recipient user can reject the share later if they so choose.
+  DatasetStore.putShareReceipt(dataset.ownerID, datasetID, recipientID, VDIDatasetShareReceipt(VDIShareReceiptAction.Accept))
+}
+
 internal fun putShareOffer(datasetID: DatasetID, ownerID: UserID, recipientID: UserID, entity: DatasetShareOffer) {
   // Lookup the target dataset or throw a 404 if it doesn't exist.
   val dataset = CacheDB.selectDataset(datasetID)


### PR DESCRIPTION
Adds a general method of authentication using an admin token/secret-key that may be used on controller methods annotated with a new `AllowAdminAuth` annotation.

The endpoints that now allow admin auth (and previously didn't) are:
* GET dataset details
* PUT dataset share offer
* PUT dataset share receipt