### PR TITLE
App db `dataset_meta`

### DIFF
--- a/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/AppDBTransaction.kt
+++ b/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/AppDBTransaction.kt
@@ -169,6 +169,18 @@ interface AppDBTransaction : AppDBAccessor, AutoCloseable {
    */
   fun insertSyncControl(sync: VDISyncControlRecord)
 
+  /**
+   * Inserts a dataset meta record for the target dataset.
+   *
+   * @param datasetID ID of the dataset for which a dataset_meta record should
+   * be inserted.
+   *
+   * @param name Name of the dataset.
+   *
+   * @param description Optional description of the dataset.
+   */
+  fun insertDatasetMeta(datasetID: DatasetID, name: String, description: String?)
+
   // endregion Insert Operations
 
   // region Update Operations
@@ -234,7 +246,35 @@ interface AppDBTransaction : AppDBAccessor, AutoCloseable {
    */
   fun updateDatasetInstallMessage(message: DatasetInstallMessage)
 
+  /**
+   * Updates the target dataset metadata with the new given values.
+   *
+   * @param datasetID ID of the dataset whose meta record will be updated.
+   *
+   * @param name Name of the dataset.
+   *
+   * @param description Optional description of the dataset.
+   */
+  fun updateDatasetMeta(datasetID: DatasetID, name: String, description: String?)
+
   // endregion Update Operations
+
+  // region Upsert Operations
+
+  /**
+   * Upserts the target dataset metadata with the given values.  If the target
+   * record already exists it will be updated, if it does not exist, it will be
+   * created.
+   *
+   * @param datasetID ID of the dataset whose meta record will be upserted.
+   *
+   * @param name Name of the dataset.
+   *
+   * @param description Optional description of the dataset.
+   */
+  fun upsertDatasetMeta(datasetID: DatasetID, name: String, description: String?)
+
+  // endregion Upsert Operations
 
   fun rollback()
 

--- a/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/AppDBTransaction.kt
+++ b/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/AppDBTransaction.kt
@@ -103,6 +103,14 @@ interface AppDBTransaction : AppDBAccessor, AutoCloseable {
    */
   fun deleteDatasetVisibility(datasetID: DatasetID, userID: UserID)
 
+  /**
+   * Deletes a specific dataset meta record.
+   *
+   * @param datasetID ID of the dataset whose dataset_meta record should be
+   * deleted.
+   */
+  fun deleteDatasetMeta(datasetID: DatasetID)
+
   // endregion Delete Operations
 
   // region Insert Operations

--- a/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/AppDBTransactionImpl.kt
+++ b/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/AppDBTransactionImpl.kt
@@ -64,6 +64,11 @@ class AppDBTransactionImpl(
     connection.deleteDatasetProjectLinks(schema, datasetID)
   }
 
+  override fun deleteDatasetMeta(datasetID: DatasetID) {
+    log.debug("deleting dataset meta for dataset {}", datasetID)
+    connection.deleteDatasetMeta(schema, datasetID)
+  }
+
 
   override fun insertDataset(dataset: DatasetRecord) {
     log.debug("inserting dataset record for dataset {}", dataset.datasetID)

--- a/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/AppDBTransactionImpl.kt
+++ b/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/AppDBTransactionImpl.kt
@@ -10,6 +10,7 @@ import org.veupathdb.vdi.lib.common.util.CloseableIterator
 import org.veupathdb.vdi.lib.db.app.model.*
 import org.veupathdb.vdi.lib.db.app.sql.*
 import java.sql.Connection
+import java.sql.SQLException
 import java.time.OffsetDateTime
 
 class AppDBTransactionImpl(
@@ -94,6 +95,11 @@ class AppDBTransactionImpl(
     connection.insertDatasetSyncControl(schema, sync)
   }
 
+  override fun insertDatasetMeta(datasetID: DatasetID, name: String, description: String?) {
+    log.debug("inserting dataset meta record for dataset {}", datasetID)
+    connection.insertDatasetMeta(schema, datasetID, name, description)
+  }
+
 
   override fun updateDataset(dataset: DatasetRecord) {
     log.debug("updating dataset record for dataset {}", dataset.datasetID)
@@ -123,6 +129,25 @@ class AppDBTransactionImpl(
   override fun updateDatasetInstallMessage(message: DatasetInstallMessage) {
     log.debug("updating dataset install message for dataset {}, install type {}", message.datasetID, message.installType)
     connection.updateDatasetInstallMessage(schema, message)
+  }
+
+  override fun updateDatasetMeta(datasetID: DatasetID, name: String, description: String?) {
+    log.debug("updating dataset meta record for dataset {}", datasetID)
+    connection.updateDatasetMeta(schema, datasetID, name, description)
+  }
+
+
+  override fun upsertDatasetMeta(datasetID: DatasetID, name: String, description: String?) {
+    try {
+      insertDatasetMeta(datasetID, name, description)
+    } catch (e: SQLException) {
+      if (e.errorCode == 1) {
+        log.debug("dataset meta record already exists for dataset {}", datasetID)
+        updateDatasetMeta(datasetID, name, description)
+      } else {
+        throw e
+      }
+    }
   }
 
 

--- a/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/sql/delete-dataset-meta.kt
+++ b/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/sql/delete-dataset-meta.kt
@@ -1,0 +1,20 @@
+package org.veupathdb.vdi.lib.db.app.sql
+
+import org.veupathdb.vdi.lib.common.field.DatasetID
+import java.sql.Connection
+
+private fun sql(schema: String) =
+// language=oracle
+"""
+DELETE FROM
+  ${schema}.dataset_meta
+WHERE
+  dataset_id = ?
+"""
+
+internal fun Connection.deleteDatasetMeta(schema: String, datasetID: DatasetID): Int =
+  prepareStatement(sql(schema))
+    .use { ps ->
+      ps.setString(1, datasetID.toString())
+      ps.executeUpdate()
+    }

--- a/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/sql/insert-dataset-meta.kt
+++ b/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/sql/insert-dataset-meta.kt
@@ -1,0 +1,28 @@
+package org.veupathdb.vdi.lib.db.app.sql
+
+import org.veupathdb.vdi.lib.common.field.DatasetID
+import org.veupathdb.vdi.lib.db.app.model.DatasetRecord
+import java.sql.Connection
+
+private fun sql(schema: String) =
+// language=oracle
+"""
+INSERT INTO
+  ${schema}.dataset_meta (
+    dataset_id
+  , name
+  , description
+  )
+VALUES
+  (?, ?, ?)
+"""
+
+internal fun Connection.insertDatasetMeta(schema: String, datasetID: DatasetID, name: String, description: String?) {
+  prepareStatement(sql(schema))
+    .use { ps ->
+      ps.setString(1, datasetID.toString())
+      ps.setString(2, name)
+      ps.setString(3, description)
+      ps.executeUpdate()
+    }
+}

--- a/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/sql/update-dataset-meta.kt
+++ b/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/sql/update-dataset-meta.kt
@@ -1,0 +1,27 @@
+package org.veupathdb.vdi.lib.db.app.sql
+
+import org.veupathdb.vdi.lib.common.field.DatasetID
+import org.veupathdb.vdi.lib.db.app.model.DatasetRecord
+import java.sql.Connection
+
+private fun sql(schema: String) =
+// language=oracle
+"""
+UPDATE
+  ${schema}.dataset_meta
+SET
+  name = ?
+, description = ?
+WHERE
+  dataset_id = ?
+"""
+
+internal fun Connection.updateDatasetMeta(schema: String, datasetID: DatasetID, name: String, description: String?) {
+  prepareStatement(sql(schema))
+    .use { ps ->
+      ps.setString(1, name)
+      ps.setString(2, description)
+      ps.setString(3, datasetID.toString())
+      ps.executeUpdate()
+    }
+}

--- a/modules/reconciler/src/main/kotlin/org/veupathdb/vdi/lib/reconciler/AppDBTarget.kt
+++ b/modules/reconciler/src/main/kotlin/org/veupathdb/vdi/lib/reconciler/AppDBTarget.kt
@@ -28,6 +28,7 @@ class AppDBTarget(
             it.deleteDatasetProjectLinks(datasetID)
             it.deleteSyncControl(datasetID)
             it.deleteInstallMessages(datasetID)
+            it.deleteDatasetMeta(datasetID)
             it.deleteDataset(datasetID)
         }
     }

--- a/modules/update-meta-trigger-handler/src/main/kotlin/vdi/module/handler/meta/triggers/UpdateMetaTriggerHandlerImpl.kt
+++ b/modules/update-meta-trigger-handler/src/main/kotlin/vdi/module/handler/meta/triggers/UpdateMetaTriggerHandlerImpl.kt
@@ -210,6 +210,9 @@ internal class UpdateMetaTriggerHandlerImpl(private val config: UpdateMetaTrigge
           it.insertDatasetProjectLink(datasetID, projectID)
         }
 
+        log.debug("upserting dataset meta record for dataset {} into app db for project {}", datasetID, projectID)
+        it.upsertDatasetMeta(datasetID, meta.name, meta.description)
+
         it.selectDatasetSyncControlRecord(datasetID) or {
           it.insertSyncControl(VDISyncControlRecord(
             datasetID     = datasetID,

--- a/schemata/ddl/oracle.sql
+++ b/schemata/ddl/oracle.sql
@@ -7,7 +7,7 @@ CREATE USER vdi IDENTIFIED BY asdfasdfasdfasdfasdf;
 ALTER USER vdi QUOTA UNLIMITED ON users;
 
 CREATE TABLE vdi.dataset (
-  dataset_id VARCHAR(32)
+  dataset_id VARCHAR2(32)
     PRIMARY KEY
     NOT NULL
 , owner NUMBER
@@ -21,8 +21,17 @@ CREATE TABLE vdi.dataset (
     NOT NULL
 );
 
+CREATE TABLE vdi.dataset_meta (
+  dataset_id VARCHAR2(32)
+    NOT NULL
+, name VARCHAR2(1024)
+    NOT NULL
+, description VARCHAR2(4000)
+, FOREIGN KEY (dataset_id) REFERENCES vdi.dataset (dataset_id)
+);
+
 CREATE TABLE vdi.sync_control (
-  dataset_id VARCHAR(32)
+  dataset_id VARCHAR2(32)
     NOT NULL
 , shares_update_time TIMESTAMP WITH TIME ZONE
     NOT NULL


### PR DESCRIPTION
We have added a new control table to the application database schema called `dataset_meta`, this PR adds methods to insert, update, and delete dataset_meta records.