### PR TITLE
Dataset deletion fixes

### DIFF
--- a/components/pruner/src/main/kotlin/vdi/component/pruner/Pruner.kt
+++ b/components/pruner/src/main/kotlin/vdi/component/pruner/Pruner.kt
@@ -144,6 +144,7 @@ object Pruner {
       it.deleteDatasetProjectLinks(datasetID)
       it.deleteSyncControl(datasetID)
       it.deleteInstallMessages(datasetID)
+      it.deleteDatasetMeta(datasetID)
       it.deleteDataset(datasetID)
     }
   }

--- a/modules/soft-delete-trigger-handler/src/main/kotlin/vdi/module/handler/delete/soft/SoftDeleteTriggerHandlerImpl.kt
+++ b/modules/soft-delete-trigger-handler/src/main/kotlin/vdi/module/handler/delete/soft/SoftDeleteTriggerHandlerImpl.kt
@@ -88,6 +88,7 @@ internal class SoftDeleteTriggerHandlerImpl(private val config: SoftDeleteTrigge
 
       if (!datasetIsInstalled(datasetID, projectID)) {
         log.info("skipping uninstall event for dataset {}/{} and project {} as it is not installed", userID, datasetID, projectID)
+        return@forEach
       }
 
       runJob(userID, datasetID, projectID, handler.client, meta)

--- a/modules/soft-delete-trigger-handler/src/main/kotlin/vdi/module/handler/delete/soft/SoftDeleteTriggerHandlerImpl.kt
+++ b/modules/soft-delete-trigger-handler/src/main/kotlin/vdi/module/handler/delete/soft/SoftDeleteTriggerHandlerImpl.kt
@@ -18,6 +18,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.veupathdb.vdi.lib.common.model.VDIDatasetMeta
+import org.veupathdb.vdi.lib.db.app.model.InstallStatus
+import org.veupathdb.vdi.lib.db.cache.model.DatasetImportStatus
 import vdi.component.metrics.Metrics
 import vdi.component.modules.VDIServiceModuleBase
 
@@ -63,6 +65,11 @@ internal class SoftDeleteTriggerHandlerImpl(private val config: SoftDeleteTrigge
     val meta = dir.getMeta().load()
       ?: throw IllegalStateException("got an uninstall event for a dataset that has no meta file: dataset $datasetID, user $userID")
 
+    if (!datasetIsImported(datasetID)) {
+      log.info("received uninstall event for a dataset that was not imported or failed import: {}/{}", userID, datasetID)
+      return
+    }
+
     val timer = Metrics.uninstallationTimes
       .labels(meta.type.name, meta.type.version)
       .startTimer()
@@ -77,6 +84,10 @@ internal class SoftDeleteTriggerHandlerImpl(private val config: SoftDeleteTrigge
       if (!handler.appliesToProject(projectID)) {
         log.warn("type handler for type {} does not apply to project {} (dataset {}, user {})", handler.type, projectID, datasetID, userID)
         return@forEach
+      }
+
+      if (!datasetIsInstalled(datasetID, projectID)) {
+        log.info("skipping uninstall event for dataset {}/{} and project {} as it is not installed", userID, datasetID, projectID)
       }
 
       runJob(userID, datasetID, projectID, handler.client, meta)
@@ -140,5 +151,21 @@ internal class SoftDeleteTriggerHandlerImpl(private val config: SoftDeleteTrigge
   private fun handleUnexpectedErrorResponse(datasetID: DatasetID, projectID: ProjectID, res: UninstallUnexpectedErrorResponse) {
     log.error("dataset handler server reports 500 for uninstall on dataset {}, project {}", datasetID, projectID)
     throw IllegalStateException(res.message)
+  }
+
+  private fun datasetIsInstalled(datasetID: DatasetID, projectID: ProjectID): Boolean {
+    val appDB = AppDB.accessor(projectID)
+
+    for (message in appDB.selectDatasetInstallMessages(datasetID)) {
+      if (message.status == InstallStatus.Complete)
+        return true
+    }
+
+    return false
+  }
+
+  private fun datasetIsImported(datasetID: DatasetID): Boolean {
+    val status = CacheDB.selectImportControl(datasetID) ?: return false
+    return status == DatasetImportStatus.Complete
   }
 }


### PR DESCRIPTION
Fixes:

* Dataset uninstaller (soft delete module) should no longer attempt to delete datasets that weren't imported.
* Dataset pruner should no longer fail for a missed table in its deletes.

Resolves #145 