### PR TITLE
Short circuit write actions to the internal postgres.

### DIFF
--- a/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/service/datasets/delete-dataset-by-id.kt
+++ b/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/service/datasets/delete-dataset-by-id.kt
@@ -28,6 +28,11 @@ internal fun deleteDataset(userID: UserID, datasetID: DatasetID) {
   if (ds.ownerID != userID)
     throw ForbiddenException()
 
-  // Put a delete flag in S3 for the target dataset.
-  DatasetStore.putDeleteFlag(userID, datasetID)
+  CacheDB.withTransaction {
+    // Update the deleted flag in the local pg.
+    it.updateDatasetDeleted(datasetID, true)
+
+    // Put a delete flag in S3 for the target dataset.
+    DatasetStore.putDeleteFlag(userID, datasetID)
+  }
 }


### PR DESCRIPTION
Change the way write actions are handled to immediately update the internal postgres instance instead of waiting for the event to come back from minio.  This is to support a synchronous seeming API for the client.