### PR TITLE
add timestamp to install messages

### DIFF
--- a/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/model/DatasetInstallMessage.kt
+++ b/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/model/DatasetInstallMessage.kt
@@ -1,6 +1,7 @@
 package org.veupathdb.vdi.lib.db.app.model
 
 import org.veupathdb.vdi.lib.common.field.DatasetID
+import java.time.OffsetDateTime
 
 /**
  * Represents a single record in the `vdi.dataset_install_messages` table.
@@ -37,4 +38,9 @@ data class DatasetInstallMessage(
    * failure messages about the installation.
    */
   val message: String?,
+
+  /**
+   * Timestamp of the message and status.
+   */
+  val updated: OffsetDateTime = OffsetDateTime.now(),
 )

--- a/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/sql/insert-dataset-install-message.kt
+++ b/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/sql/insert-dataset-install-message.kt
@@ -2,6 +2,7 @@ package org.veupathdb.vdi.lib.db.app.sql
 
 import org.veupathdb.vdi.lib.db.app.model.DatasetInstallMessage
 import java.sql.Connection
+import java.time.OffsetDateTime
 
 private fun sql(schema: String) =
 // language=oracle
@@ -12,9 +13,10 @@ INSERT INTO
   , install_type
   , status
   , message
+  , updated
   )
 VALUES
-  (?, ?, ?, ?)
+  (?, ?, ?, ?, ?)
 """
 
 internal fun Connection.insertDatasetInstallMessage(schema: String, message: DatasetInstallMessage) {
@@ -24,6 +26,7 @@ internal fun Connection.insertDatasetInstallMessage(schema: String, message: Dat
       ps.setString(2, message.installType.value)
       ps.setString(3, message.status.value)
       ps.setString(4, message.message)
+      ps.setObject(5, message.updated)
       ps.executeUpdate()
     }
 }

--- a/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/sql/select-dataset-install-message.kt
+++ b/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/sql/select-dataset-install-message.kt
@@ -5,6 +5,7 @@ import org.veupathdb.vdi.lib.db.app.model.DatasetInstallMessage
 import org.veupathdb.vdi.lib.db.app.model.InstallStatus
 import org.veupathdb.vdi.lib.db.app.model.InstallType
 import java.sql.Connection
+import java.time.OffsetDateTime
 
 private fun sql(schema: String) =
 // language=oracle
@@ -12,6 +13,7 @@ private fun sql(schema: String) =
 SELECT
   status
 , message
+, updated
 FROM
   ${schema}.dataset_install_message
 WHERE
@@ -36,7 +38,8 @@ internal fun Connection.selectDatasetInstallMessage(
         datasetID   = datasetID,
         installType = installType,
         status      = InstallStatus.fromString(rs.getString("status")),
-        message     = rs.getString("message")
+        message     = rs.getString("message"),
+        updated     = rs.getObject("updated", OffsetDateTime::class.java),
       )
     }
   }

--- a/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/sql/select-dataset-install-messages.kt
+++ b/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/sql/select-dataset-install-messages.kt
@@ -5,6 +5,7 @@ import org.veupathdb.vdi.lib.db.app.model.DatasetInstallMessage
 import org.veupathdb.vdi.lib.db.app.model.InstallStatus
 import org.veupathdb.vdi.lib.db.app.model.InstallType
 import java.sql.Connection
+import java.time.OffsetDateTime
 
 private fun sql(schema: String) =
 // language=oracle
@@ -13,6 +14,7 @@ SELECT
   install_type
 , status
 , message
+, updated
 FROM
   ${schema}.dataset_install_message
 WHERE
@@ -37,7 +39,8 @@ internal fun Connection.selectDatasetInstallMessages(
           datasetID   = datasetID,
           installType = InstallType.fromString(rs.getString("install_type")),
           status      = InstallStatus.fromString(rs.getString("status")),
-          message     = rs.getString("message")
+          message     = rs.getString("message"),
+          updated     = rs.getObject("updated", OffsetDateTime::class.java)
         ))
       } while (rs.next())
 

--- a/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/sql/update-dataset-install-message.kt
+++ b/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/sql/update-dataset-install-message.kt
@@ -11,6 +11,7 @@ UPDATE
 SET
   status = ?
 , message = ?
+, updated = ?
 WHERE
   dataset_id = ?
   AND install_type = ?
@@ -21,8 +22,9 @@ internal fun Connection.updateDatasetInstallMessage(schema: String, message: Dat
     .use { ps ->
       ps.setString(1, message.status.value)
       ps.setString(2, message.message)
-      ps.setString(3, message.datasetID.toString())
-      ps.setString(4, message.installType.value)
+      ps.setObject(3, message.updated)
+      ps.setString(4, message.datasetID.toString())
+      ps.setString(5, message.installType.value)
       ps.executeUpdate()
     }
 }


### PR DESCRIPTION
Adds a timestamp field to the dataset message record type to match the addition of the field in the vdi app db control tables.