### PR TITLE
re-add rabbitmq docker-network for local dev

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -92,5 +92,7 @@ services:
     - kafka
     - rabbit-external
     - minio-external
+    networks:
+    - rabbitmq
     ports:
     - "8080:${VDI_SERVICE_HTTP_PORT:-80}"


### PR DESCRIPTION
The network was dropped from the primary docker compose file and is now being readded to the dev compose file to re-enable local development of the VDI stack.