### PR TITLE
Handle the case where a project with datasets is disabled

### DIFF
--- a/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/AppDB.kt
+++ b/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/AppDB.kt
@@ -47,13 +47,13 @@ object AppDB {
     return out
   }
 
-  fun accessor(key: ProjectID): AppDBAccessor =
-    AppDatabaseRegistry.require(key)
-      .let { AppDBAccessorImpl(it.ctlSchema, it.source) }
+  fun accessor(key: ProjectID): AppDBAccessor? =
+    AppDatabaseRegistry[key]
+      ?.let { AppDBAccessorImpl(it.ctlSchema, it.source) }
 
-  fun transaction(key: ProjectID): AppDBTransaction =
-    AppDatabaseRegistry.require(key)
-      .let { ds -> AppDBTransactionImpl(ds.ctlSchema, ds.source.connection.also { it.autoCommit = false }) }
+  fun transaction(key: ProjectID): AppDBTransaction? =
+    AppDatabaseRegistry[key]
+      ?.let { ds -> AppDBTransactionImpl(ds.ctlSchema, ds.source.connection.also { it.autoCommit = false }) }
 
   /**
    * Executes the given function ([fn]) in the context of a database
@@ -87,7 +87,7 @@ object AppDB {
 
     log.trace("withTransaction(projectID={}, fn=...)", projectID)
 
-    val trans = transaction(projectID)
+    val trans = transaction(projectID)!!
     val out: T
 
     try {

--- a/components/dataset-reinstaller/src/main/kotlin/vdi/component/reinstaller/DatasetReinstaller.kt
+++ b/components/dataset-reinstaller/src/main/kotlin/vdi/component/reinstaller/DatasetReinstaller.kt
@@ -76,7 +76,7 @@ object DatasetReinstaller {
 
   private fun processProject(projectID: ProjectID) {
     // locate datasets in the ready-for-reinstall status
-    val datasets = AppDB.accessor(projectID)
+    val datasets = AppDB.accessor(projectID)!!
       .selectDatasetsByInstallStatus(InstallType.Data, InstallStatus.ReadyForReinstall)
 
     log.info("found {} datasets in project {} that are ready for reinstall", datasets.size, projectID)

--- a/components/install-cleanup/src/main/kotlin/vdi/component/install_cleanup/InstallCleaner.kt
+++ b/components/install-cleanup/src/main/kotlin/vdi/component/install_cleanup/InstallCleaner.kt
@@ -29,7 +29,7 @@ object InstallCleaner {
     for ((projectID, _) in AppDatabaseRegistry) {
       try {
         // Fetch a list of datasets with broken installs
-        val targets = AppDB.accessor(projectID)
+        val targets = AppDB.accessor(projectID)!!
           .selectDatasetsByInstallStatus(InstallType.Data, InstallStatus.FailedInstallation)
 
         log.info("found {} broken datasets for cleanup in project {}", targets.size, projectID)
@@ -76,8 +76,15 @@ object InstallCleaner {
    */
   private fun maybeCleanDatasetFromTargetDB(datasetID: DatasetID, projectID: ProjectID) {
     try {
+      val accessor = AppDB.accessor(projectID)
+
+      if (accessor == null) {
+        log.info("Skipping database clean for dataset {} project {} as the target project is not currently enabled.", datasetID, projectID)
+        return
+      }
+
       // Lookup the existing install message for the dataset
-      val message = AppDB.accessor(projectID).selectDatasetInstallMessage(datasetID, InstallType.Data)
+      val message = accessor.selectDatasetInstallMessage(datasetID, InstallType.Data)
 
       // If one does not exist, then the dataset was never installed in the
       // first place.

--- a/components/pruner/src/main/kotlin/vdi/component/pruner/Pruner.kt
+++ b/components/pruner/src/main/kotlin/vdi/component/pruner/Pruner.kt
@@ -5,6 +5,7 @@ import org.veupathdb.lib.s3.s34k.S3Api
 import org.veupathdb.lib.s3.s34k.buckets.S3Bucket
 import org.veupathdb.vdi.lib.common.field.ProjectID
 import org.veupathdb.vdi.lib.db.app.AppDB
+import org.veupathdb.vdi.lib.db.app.AppDatabaseRegistry
 import org.veupathdb.vdi.lib.db.cache.CacheDB
 import org.veupathdb.vdi.lib.db.cache.model.DeletedDataset
 import org.veupathdb.vdi.lib.s3.datasets.DatasetManager
@@ -137,6 +138,11 @@ object Pruner {
   }
 
   private fun DeletedDataset.deleteFromAppDB(projectID: ProjectID) {
+    if (projectID !in AppDatabaseRegistry) {
+      log.info("Cannot delete dataset {}/{} from project {} due to target project config being disabled.", ownerID, datasetID, projectID)
+      return
+    }
+
     log.debug("deleting dataset {} from project {} app DB", datasetID, projectID)
 
     AppDB.withTransaction(projectID) {

--- a/modules/install-trigger-handler/src/main/kotlin/vdi/module/handler/install/data/InstallDataTriggerHandlerImpl.kt
+++ b/modules/install-trigger-handler/src/main/kotlin/vdi/module/handler/install/data/InstallDataTriggerHandlerImpl.kt
@@ -181,8 +181,12 @@ internal class InstallDataTriggerHandlerImpl(private val config: InstallTriggerH
     log.trace("executeJob(userID={}, datasetID={}, projectID={}, s3Dir=..., handler=...)", userID, datasetID, projectID)
 
     val appDB   = AppDB.accessor(projectID)
-    val dataset = appDB.selectDataset(datasetID)
+    if (appDB == null) {
+      log.info("skipping install event for dataset {}/{} into project {} due to the target project being disabled.", userID, datasetID, projectID)
+      return
+    }
 
+    val dataset = appDB.selectDataset(datasetID)
     if (dataset == null) {
       log.info("skipping install event for dataset {}/{} into project {} due to no dataset record being present", userID, datasetID, projectID)
       return

--- a/modules/reconciler/src/main/kotlin/org/veupathdb/vdi/lib/reconciler/AppDBTarget.kt
+++ b/modules/reconciler/src/main/kotlin/org/veupathdb/vdi/lib/reconciler/AppDBTarget.kt
@@ -14,7 +14,7 @@ class AppDBTarget(
 ) : ReconcilerTarget {
 
     override fun streamSortedSyncControlRecords(): CloseableIterator<Pair<VDIDatasetType, VDISyncControlRecord>> {
-        return AppDB.accessor(projectID).streamAllSyncControlRecords()
+        return AppDB.accessor(projectID)!!.streamAllSyncControlRecords()
     }
 
     override fun deleteDataset(datasetType: VDIDatasetType, datasetID: DatasetID) {

--- a/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/service/datasets/list-broken.kt
+++ b/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/service/datasets/list-broken.kt
@@ -94,7 +94,7 @@ private fun listExpandedBrokenDatasets(): BrokenDatasetListing {
 }
 
 private fun getBrokenDatasets(projectID: ProjectID) =
-  AppDB.accessor(projectID)
+  AppDB.accessor(projectID)!!
     .selectDatasetsByInstallStatus(InstallType.Data, InstallStatus.FailedInstallation)
 
 private fun DatasetRecord.toDetails(


### PR DESCRIPTION
Previously on reconciler or reinstaller runs, if a dataset was targetting a project that has been disabled, it would throw an exception.  The exceptions were harmless but noisy, this PR adjusts the trigger handlers to log a message instead of throwing an exception when a dataset's target project is no longer enabled.