### PR TITLE
Add version ID to MinIO s3 event object

### DIFF
--- a/modules/event-router/src/main/kotlin/vdi/module/events/routing/model/MinIOEventRecordS3Object.kt
+++ b/modules/event-router/src/main/kotlin/vdi/module/events/routing/model/MinIOEventRecordS3Object.kt
@@ -2,6 +2,12 @@ package vdi.module.events.routing.model
 
 import com.fasterxml.jackson.annotation.JsonProperty
 
+/**
+ * Representation of the S3 record in MinIO event message. I wasn't able to find the structure documented in MinIO
+ * docs, but it should be compatible with the S3 structure:
+ *
+ * https://docs.aws.amazon.com/AmazonS3/latest/userguide/notification-content-structure.html
+ */
 data class MinIOEventRecordS3Object(
   @JsonProperty("key")
   val key: String,
@@ -20,4 +26,7 @@ data class MinIOEventRecordS3Object(
 
   @JsonProperty("sequencer")
   val sequencer: String,
+
+  @JsonProperty("versionId")
+  val versionId: String?,
 )


### PR DESCRIPTION
## Overview
Because versioning is enabled in dev MinIO, the versionId field is being populated. This PR supports parsing that field, though it is not used in any way currently as objects should never be overwritten with differing contents.