### PR TITLE
Remove case sensitivity from comparisons to be compatible with MinIO sorts

### DIFF
--- a/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/sql/select-all-sync-control.kt
+++ b/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/sql/select-all-sync-control.kt
@@ -24,7 +24,7 @@ FROM
   ${schema}.sync_control s
   INNER JOIN ${schema}.dataset d
     ON d.dataset_id = s.dataset_id
-ORDER BY CONCAT(CONCAT(d.owner,'/'), s.dataset_id)
+ORDER BY UPPER(CONCAT(CONCAT(d.owner,'/'), s.dataset_id))
 """
 
 internal fun Connection.selectAllSyncControl(schema: String): CloseableIterator<Pair<VDIDatasetType, VDISyncControlRecord>> {

--- a/components/cache-db/src/main/kotlin/org/veupathdb/vdi/lib/db/cache/sql/select/select-all-sync-control.kt
+++ b/components/cache-db/src/main/kotlin/org/veupathdb/vdi/lib/db/cache/sql/select/select-all-sync-control.kt
@@ -23,7 +23,7 @@ FROM
   vdi.sync_control AS s
   INNER JOIN vdi.datasets AS d
     USING (dataset_id)
-ORDER BY CONCAT(d.owner_id,'/',s.dataset_id)
+ORDER BY UPPER(CONCAT(d.owner_id,'/',s.dataset_id))
 """
 
 internal fun Connection.selectAllSyncControl(): CloseableIterator<Pair<VDIDatasetType, VDISyncControlRecord>> {

--- a/components/metrics/src/main/kotlin/vdi/component/metrics/Metrics.kt
+++ b/components/metrics/src/main/kotlin/vdi/component/metrics/Metrics.kt
@@ -127,6 +127,30 @@ object Metrics {
     )
     .register()
 
+  val failedReconciliation: Counter = Counter.build()
+    .name("dataset_reconiler_failed")
+    .help("Count of failed reconciler runs.")
+    .labelNames("target_name")
+    .register()
+
+  val reconcilerDatasetDeleted: Counter = Counter.build()
+    .name("dataset_reconciler_deleted")
+    .help("Count of datasets deleted by reconciler.")
+    .labelNames("target_name")
+    .register()
+
+  val reconcilerDatasetSynced: Counter = Counter.build()
+    .name("dataset_reconciler_synced")
+    .help("Count of datasets synced by reconciler.")
+    .labelNames("target_name")
+    .register()
+
+  val malformedDatasetFound: Counter = Counter.build()
+    .name("malformed_dataset_found")
+    .help("A Malformed dataset was found during reconciliation.")
+    .labelNames("target_name")
+    .register()
+
   val reconcilerTimes: Histogram = Histogram.build()
     .name("dataset_reconciler_times")
     .help("Dataset reconciler run times.")

--- a/components/s3/src/main/kotlin/org/veupathdb/vdi/lib/s3/datasets/EagerlyLoadedDatasetDirectory.kt
+++ b/components/s3/src/main/kotlin/org/veupathdb/vdi/lib/s3/datasets/EagerlyLoadedDatasetDirectory.kt
@@ -5,6 +5,7 @@ import org.veupathdb.vdi.lib.common.field.DatasetID
 import org.veupathdb.vdi.lib.common.field.UserID
 import org.veupathdb.vdi.lib.common.field.toUserIDOrNull
 import org.veupathdb.vdi.lib.common.model.*
+import org.veupathdb.vdi.lib.s3.datasets.exception.MalformedDatasetException
 import org.veupathdb.vdi.lib.s3.datasets.paths.S3DatasetPathFactory
 import org.veupathdb.vdi.lib.s3.datasets.paths.S3Paths
 import vdi.constants.InstallZipName
@@ -161,7 +162,7 @@ private fun S3Object.toDatasetFile(pathFactory: S3DatasetPathFactory): DatasetFi
     )
     this.path.contains(pathFactory.datasetDeleteFlagFile()) -> DatasetDeleteFlagFileImpl(this)
     this.path.contains(pathFactory.datasetUploadsDir()) -> DatasetUploadFileImpl(this)
-    else -> throw IllegalStateException("Unable to create a dataset file from path " + this.path)
+    else -> throw MalformedDatasetException("Unrecognized file path in S3: " + this.path)
   }
   return datasetFile
 }

--- a/components/s3/src/main/kotlin/org/veupathdb/vdi/lib/s3/datasets/exception/MalformedDatasetException.kt
+++ b/components/s3/src/main/kotlin/org/veupathdb/vdi/lib/s3/datasets/exception/MalformedDatasetException.kt
@@ -1,0 +1,4 @@
+package org.veupathdb.vdi.lib.s3.datasets.exception
+
+class MalformedDatasetException(message: String?) : Exception(message) {
+}

--- a/modules/reconciler/src/main/kotlin/org/veupathdb/vdi/lib/reconciler/ReconcilerImpl.kt
+++ b/modules/reconciler/src/main/kotlin/org/veupathdb/vdi/lib/reconciler/ReconcilerImpl.kt
@@ -51,7 +51,7 @@ class ReconcilerImpl(private val config: ReconcilerConfig) :
               contextData = ThreadContextData( // Add log4j context to reconciler to distinguish targets in logs.
                 map = mapOf(
                   Pair(
-                    "reconciler",
+                    "workerID",
                     target.name
                   )
                 ), Stack()

--- a/modules/reconciler/src/test/kotlin/org/veupathdb/vdi/lib/reconciler/ReconcilerTest.kt
+++ b/modules/reconciler/src/test/kotlin/org/veupathdb/vdi/lib/reconciler/ReconcilerTest.kt
@@ -25,6 +25,7 @@ class ReconcilerTest {
     @DisplayName("Test insert one, delete one at the end")
     fun test1() {
         val cacheDb = mock<ReconcilerTarget>()
+        `when`(cacheDb.name).thenReturn("CacheDB")
         val datasetManager = mock<DatasetManager>()
         val kafkaRouter = mock<KafkaRouter>()
 
@@ -82,6 +83,7 @@ class ReconcilerTest {
     @DisplayName("Test single dataset out of sync")
     fun test2() {
         val cacheDb = mock<ReconcilerTarget>()
+        `when`(cacheDb.name).thenReturn("CacheDB")
         val datasetManager = mock<DatasetManager>()
         val kafkaRouter = mock<KafkaRouter>()
         val recon = ReconcilerInstance(cacheDb, datasetManager, kafkaRouter)
@@ -116,6 +118,7 @@ class ReconcilerTest {
     @DisplayName("Test single dataset in sync")
     fun test3() {
         val cacheDb = mock<ReconcilerTarget>()
+        `when`(cacheDb.name).thenReturn("CacheDB")
         val datasetManager = mock<DatasetManager>()
         val kafkaRouter = mock<KafkaRouter>()
         val recon = ReconcilerInstance(cacheDb, datasetManager, kafkaRouter)
@@ -145,6 +148,7 @@ class ReconcilerTest {
     @DisplayName("Test target DB missing all datasets")
     fun test4() {
         val cacheDb = mock<ReconcilerTarget>()
+        `when`(cacheDb.name).thenReturn("CacheDB")
         val datasetManager = mock<DatasetManager>()
         val kafkaRouter = mock<KafkaRouter>()
         val recon = ReconcilerInstance(cacheDb, datasetManager, kafkaRouter)
@@ -167,6 +171,7 @@ class ReconcilerTest {
     @DisplayName("Test delete one in the middle")
     fun test5() {
         val cacheDb = mock<ReconcilerTarget>()
+        `when`(cacheDb.name).thenReturn("CacheDB")
         val datasetManager = mock<DatasetManager>()
         val kafkaRouter = mock<KafkaRouter>()
 
@@ -225,6 +230,7 @@ class ReconcilerTest {
     @DisplayName("Test delete last datasets in target stream, then sync last source")
     fun test6() {
         val cacheDb = mock<ReconcilerTarget>()
+        `when`(cacheDb.name).thenReturn("CacheDB")
         val datasetManager = mock<DatasetManager>()
         val kafkaRouter = mock<KafkaRouter>()
         val recon = ReconcilerInstance(cacheDb, datasetManager, kafkaRouter)
@@ -280,6 +286,7 @@ class ReconcilerTest {
     @DisplayName("Test case sensitivity")
     fun test7() {
         val cacheDb = mock<ReconcilerTarget>()
+        `when`(cacheDb.name).thenReturn("CacheDB")
         val datasetManager = mock<DatasetManager>()
         val kafkaRouter = mock<KafkaRouter>()
         val recon = ReconcilerInstance(cacheDb, datasetManager, kafkaRouter)

--- a/src/main/resources/log4j2.yml
+++ b/src/main/resources/log4j2.yml
@@ -7,10 +7,6 @@ Configuration:
       target: SYSTEM_OUT
       PatternLayout:
         pattern: "%highlight{%d{yyyy-MM-dd HH:mm:ss.SSS} (wid:%X{workerID}) [rid:%5X{traceId}] %-5level %c - %m%n}"
-    - name: Reconciler_Appender
-      target: SYSTEM_OUT
-      PatternLayout:
-        pattern: "%highlight{%d{yyyy-MM-dd HH:mm:ss.SSS} [reconciler:%5X{reconciler}] %-5level %c - %m%n}"
 
   Loggers:
     Root:
@@ -33,8 +29,3 @@ Configuration:
       additivity: false
       AppenderRef:
         - ref: Console_Appender
-    - name: org.veupathdb.vdi.lib.reconciler
-      level: debug
-      additivity: false
-      AppenderRef:
-      - ref: Reconciler_Appender


### PR DESCRIPTION
## Overview
Ensure comparisons are in sync across MinIO, database and comparisons in code.

The MinIO list objects results are sorted ignoring case, which is a little unusual as it's not in accordance with UTF-8 ordering. Kotlin, Java, Oracle and Postgres all use UTF-8 sorting. I updated all sorts to be case-insensitive.

I also added a malformed dataset exception that gets gracefully handled in the reconciler.