### PR TITLE
Fix the sort to use owner ID

### DIFF
--- a/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/AppDBAccessor.kt
+++ b/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/AppDBAccessor.kt
@@ -3,7 +3,7 @@ package org.veupathdb.vdi.lib.db.app
 import org.veupathdb.vdi.lib.common.field.DatasetID
 import org.veupathdb.vdi.lib.common.field.ProjectID
 import org.veupathdb.vdi.lib.common.field.UserID
-import org.veupathdb.vdi.lib.common.model.VDIDatasetType
+import org.veupathdb.vdi.lib.common.model.VDIReconcilerTargetRecord
 import org.veupathdb.vdi.lib.common.model.VDISyncControlRecord
 import org.veupathdb.vdi.lib.common.util.CloseableIterator
 import org.veupathdb.vdi.lib.db.app.model.*
@@ -84,7 +84,7 @@ interface AppDBAccessor {
    * @return Stream of dataset control records sorted by user ID and then dataset ID. The stream
    * must be closed to release the db connection.
    */
-  fun streamAllSyncControlRecords(): CloseableIterator<Pair<VDIDatasetType, VDISyncControlRecord>>
+  fun streamAllSyncControlRecords(): CloseableIterator<VDIReconcilerTargetRecord>
 
   /**
    * Retrieves all datasets that have an install message record for the given

--- a/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/AppDBAccessorImpl.kt
+++ b/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/AppDBAccessorImpl.kt
@@ -4,7 +4,7 @@ import org.slf4j.LoggerFactory
 import org.veupathdb.vdi.lib.common.field.DatasetID
 import org.veupathdb.vdi.lib.common.field.ProjectID
 import org.veupathdb.vdi.lib.common.field.UserID
-import org.veupathdb.vdi.lib.common.model.VDIDatasetType
+import org.veupathdb.vdi.lib.common.model.VDIReconcilerTargetRecord
 import org.veupathdb.vdi.lib.common.model.VDISyncControlRecord
 import org.veupathdb.vdi.lib.common.util.CloseableIterator
 import org.veupathdb.vdi.lib.db.app.model.*
@@ -55,7 +55,7 @@ internal class AppDBAccessorImpl(
     return con.use { it.selectDatasetProjectLinks(schema, datasetID) }
   }
 
-  override fun streamAllSyncControlRecords(): CloseableIterator<Pair<VDIDatasetType, VDISyncControlRecord>> {
+  override fun streamAllSyncControlRecords(): CloseableIterator<VDIReconcilerTargetRecord> {
     log.debug("Streaming all sync control records")
     return con.selectAllSyncControl(schema)
   }

--- a/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/AppDBTransactionImpl.kt
+++ b/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/AppDBTransactionImpl.kt
@@ -4,7 +4,7 @@ import org.slf4j.LoggerFactory
 import org.veupathdb.vdi.lib.common.field.DatasetID
 import org.veupathdb.vdi.lib.common.field.ProjectID
 import org.veupathdb.vdi.lib.common.field.UserID
-import org.veupathdb.vdi.lib.common.model.VDIDatasetType
+import org.veupathdb.vdi.lib.common.model.VDIReconcilerTargetRecord
 import org.veupathdb.vdi.lib.common.model.VDISyncControlRecord
 import org.veupathdb.vdi.lib.common.util.CloseableIterator
 import org.veupathdb.vdi.lib.db.app.model.*
@@ -198,7 +198,7 @@ class AppDBTransactionImpl(
     return connection.selectDatasetProjectLinks(schema, datasetID)
   }
 
-  override fun streamAllSyncControlRecords(): CloseableIterator<Pair<VDIDatasetType, VDISyncControlRecord>> {
+  override fun streamAllSyncControlRecords(): CloseableIterator<VDIReconcilerTargetRecord> {
     return connection.selectAllSyncControl(schema)
   }
 

--- a/components/cache-db/src/main/kotlin/org/veupathdb/vdi/lib/db/cache/CacheDB.kt
+++ b/components/cache-db/src/main/kotlin/org/veupathdb/vdi/lib/db/cache/CacheDB.kt
@@ -7,6 +7,7 @@ import org.veupathdb.vdi.lib.common.env.*
 import org.veupathdb.vdi.lib.common.field.DatasetID
 import org.veupathdb.vdi.lib.common.field.UserID
 import org.veupathdb.vdi.lib.common.model.VDIDatasetType
+import org.veupathdb.vdi.lib.common.model.VDIReconcilerTargetRecord
 import org.veupathdb.vdi.lib.common.model.VDISyncControlRecord
 import org.veupathdb.vdi.lib.common.util.CloseableIterator
 import org.veupathdb.vdi.lib.db.cache.model.*
@@ -173,7 +174,7 @@ object CacheDB {
    * @return Stream of dataset control records sorted by user ID and then dataset ID. The stream
    * must be closed to release the db connection.
    */
-  fun selectAllSyncControlRecords(): CloseableIterator<Pair<VDIDatasetType, VDISyncControlRecord>> {
+  fun selectAllSyncControlRecords(): CloseableIterator<VDIReconcilerTargetRecord> {
     log.debug("selecting all sync control records")
     return connection.selectAllSyncControl()
   }

--- a/components/metrics/src/main/kotlin/vdi/component/metrics/Metrics.kt
+++ b/components/metrics/src/main/kotlin/vdi/component/metrics/Metrics.kt
@@ -145,10 +145,15 @@ object Metrics {
     .labelNames("target_name")
     .register()
 
+  val missingInTarget: Counter = Counter.build()
+    .name("dataset_reconciler_missing_in_target")
+    .help("Count of datasets the reconciler finds are missing in the target DB.")
+    .labelNames("target_name")
+    .register()
+
   val malformedDatasetFound: Counter = Counter.build()
     .name("malformed_dataset_found")
     .help("A Malformed dataset was found during reconciliation.")
-    .labelNames("target_name")
     .register()
 
   val reconcilerTimes: Histogram = Histogram.build()

--- a/components/s3/build.gradle.kts
+++ b/components/s3/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 dependencies {
   implementation(platform(project(":platform")))
 
+  implementation(project(":components:metrics"))
   implementation(project(":components:constants"))
 
   implementation("org.veupathdb.vdi:vdi-component-common")

--- a/modules/reconciler/src/main/kotlin/org/veupathdb/vdi/lib/reconciler/AppDBTarget.kt
+++ b/modules/reconciler/src/main/kotlin/org/veupathdb/vdi/lib/reconciler/AppDBTarget.kt
@@ -2,7 +2,7 @@ package org.veupathdb.vdi.lib.reconciler
 
 import org.veupathdb.vdi.lib.common.field.DatasetID
 import org.veupathdb.vdi.lib.common.model.VDIDatasetType
-import org.veupathdb.vdi.lib.common.model.VDISyncControlRecord
+import org.veupathdb.vdi.lib.common.model.VDIReconcilerTargetRecord
 import org.veupathdb.vdi.lib.common.util.CloseableIterator
 import org.veupathdb.vdi.lib.db.app.AppDB
 import org.veupathdb.vdi.lib.handler.mapping.PluginHandlers
@@ -15,7 +15,7 @@ class AppDBTarget(
 
     override val type = ReconcilerTargetType.Install
 
-    override fun streamSortedSyncControlRecords(): CloseableIterator<Pair<VDIDatasetType, VDISyncControlRecord>> {
+    override fun streamSortedSyncControlRecords(): CloseableIterator<VDIReconcilerTargetRecord> {
         return AppDB.accessor(projectID)!!.streamAllSyncControlRecords()
     }
 

--- a/modules/reconciler/src/main/kotlin/org/veupathdb/vdi/lib/reconciler/CacheDBTarget.kt
+++ b/modules/reconciler/src/main/kotlin/org/veupathdb/vdi/lib/reconciler/CacheDBTarget.kt
@@ -2,7 +2,7 @@ package org.veupathdb.vdi.lib.reconciler
 
 import org.veupathdb.vdi.lib.common.field.DatasetID
 import org.veupathdb.vdi.lib.common.model.VDIDatasetType
-import org.veupathdb.vdi.lib.common.model.VDISyncControlRecord
+import org.veupathdb.vdi.lib.common.model.VDIReconcilerTargetRecord
 import org.veupathdb.vdi.lib.common.util.CloseableIterator
 import org.veupathdb.vdi.lib.db.cache.CacheDB
 import org.veupathdb.vdi.lib.db.cache.CacheDBTransaction
@@ -12,7 +12,7 @@ class CacheDBTarget : ReconcilerTarget {
 
     override val type = ReconcilerTargetType.Cache
 
-    override fun streamSortedSyncControlRecords(): CloseableIterator<Pair<VDIDatasetType, VDISyncControlRecord>> {
+    override fun streamSortedSyncControlRecords(): CloseableIterator<VDIReconcilerTargetRecord> {
         return CacheDB.selectAllSyncControlRecords()
     }
 

--- a/modules/reconciler/src/main/kotlin/org/veupathdb/vdi/lib/reconciler/ReconcilerTarget.kt
+++ b/modules/reconciler/src/main/kotlin/org/veupathdb/vdi/lib/reconciler/ReconcilerTarget.kt
@@ -2,7 +2,7 @@ package org.veupathdb.vdi.lib.reconciler
 
 import org.veupathdb.vdi.lib.common.field.DatasetID
 import org.veupathdb.vdi.lib.common.model.VDIDatasetType
-import org.veupathdb.vdi.lib.common.model.VDISyncControlRecord
+import org.veupathdb.vdi.lib.common.model.VDIReconcilerTargetRecord
 import org.veupathdb.vdi.lib.common.util.CloseableIterator
 
 /**
@@ -26,7 +26,7 @@ interface ReconcilerTarget {
    *
    * Note that the returned iterator must be closed to avoid connection leaks.
    */
-  fun streamSortedSyncControlRecords(): CloseableIterator<Pair<VDIDatasetType, VDISyncControlRecord>>
+  fun streamSortedSyncControlRecords(): CloseableIterator<VDIReconcilerTargetRecord>
 
   fun deleteDataset(datasetType: VDIDatasetType, datasetID: DatasetID)
 }

--- a/modules/reconciler/src/test/kotlin/org/veupathdb/vdi/lib/reconciler/ReconcilerTest.kt
+++ b/modules/reconciler/src/test/kotlin/org/veupathdb/vdi/lib/reconciler/ReconcilerTest.kt
@@ -5,8 +5,8 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.*
 import org.veupathdb.vdi.lib.common.field.DatasetID
 import org.veupathdb.vdi.lib.common.field.UserID
-import org.veupathdb.vdi.lib.common.model.VDIDatasetType
 import org.veupathdb.vdi.lib.common.model.VDIDatasetTypeImpl
+import org.veupathdb.vdi.lib.common.model.VDIReconcilerTargetRecord
 import org.veupathdb.vdi.lib.common.model.VDISyncControlRecord
 import org.veupathdb.vdi.lib.common.util.CloseableIterator
 import org.veupathdb.vdi.lib.kafka.model.triggers.UpdateMetaTrigger
@@ -29,14 +29,15 @@ class ReconcilerTest {
         val datasetManager = mock<DatasetManager>()
         val kafkaRouter = mock<KafkaRouter>()
 
-        val recon = ReconcilerInstance(cacheDb, datasetManager, kafkaRouter)
+        val recon = ReconcilerInstance(cacheDb, datasetManager, kafkaRouter, false)
 
         `when`(cacheDb.streamSortedSyncControlRecords()).thenReturn(
             closeableIterator(
                 listOf(
-                    Pair(
-                        VDIDatasetTypeImpl("Stub", "Stub"),
-                        VDISyncControlRecord(
+                    VDIReconcilerTargetRecord(
+                        type = VDIDatasetTypeImpl("Stub", "Stub"),
+                        owner = UserID("111"),
+                        syncControlRecord = VDISyncControlRecord(
                             datasetID = DatasetID("12345678123456781234567812345678"),
                             sharesUpdated = UpdateTime,
                             dataUpdated = UpdateTime,
@@ -44,18 +45,20 @@ class ReconcilerTest {
                         )
                     ),
                     // Missing 22345678123456781234567812345678, should be inserted in target.
-                    Pair(
-                        VDIDatasetTypeImpl("Stub", "Stub"),
-                        VDISyncControlRecord(
+                    VDIReconcilerTargetRecord(
+                        type = VDIDatasetTypeImpl("Stub", "Stub"),
+                        owner = UserID("111"),
+                        syncControlRecord = VDISyncControlRecord(
                             datasetID = DatasetID("32345678123456781234567812345678"),
                             sharesUpdated = UpdateTime,
                             dataUpdated = UpdateTime,
                             metaUpdated = UpdateTime
                         )
                     ),
-                    Pair(
-                        VDIDatasetTypeImpl("Stub", "Stub"),
-                        VDISyncControlRecord(
+                    VDIReconcilerTargetRecord(
+                        type = VDIDatasetTypeImpl("Stub", "Stub"),
+                        owner = UserID("111"),
+                syncControlRecord = VDISyncControlRecord(
                             datasetID = DatasetID("42345678123456781234567812345678"),
                             sharesUpdated = UpdateTime,
                             dataUpdated = UpdateTime,
@@ -86,14 +89,15 @@ class ReconcilerTest {
         `when`(cacheDb.name).thenReturn("CacheDB")
         val datasetManager = mock<DatasetManager>()
         val kafkaRouter = mock<KafkaRouter>()
-        val recon = ReconcilerInstance(cacheDb, datasetManager, kafkaRouter)
+        val recon = ReconcilerInstance(cacheDb, datasetManager, kafkaRouter, false)
 
         `when`(cacheDb.streamSortedSyncControlRecords()).thenReturn(
             closeableIterator(
                 listOf(
-                    Pair(
-                        VDIDatasetTypeImpl("Stub", "Stub"),
-                        VDISyncControlRecord(
+                    VDIReconcilerTargetRecord(
+                        type = VDIDatasetTypeImpl("Stub", "Stub"),
+                        owner = UserID("111"),
+                        syncControlRecord = VDISyncControlRecord(
                             datasetID = DatasetID("12345678123456781234567812345678"),
                             sharesUpdated = UpdateTime,
                             dataUpdated = UpdateTime,
@@ -121,13 +125,15 @@ class ReconcilerTest {
         `when`(cacheDb.name).thenReturn("CacheDB")
         val datasetManager = mock<DatasetManager>()
         val kafkaRouter = mock<KafkaRouter>()
-        val recon = ReconcilerInstance(cacheDb, datasetManager, kafkaRouter)
+        val recon = ReconcilerInstance(cacheDb, datasetManager, kafkaRouter, false)
 
         `when`(cacheDb.streamSortedSyncControlRecords()).thenReturn(
             closeableIterator(
                 listOf(
-                    Pair(
-                        VDIDatasetTypeImpl("Stub", "Stub"), VDISyncControlRecord(
+                    VDIReconcilerTargetRecord(
+                        type = VDIDatasetTypeImpl("Stub", "Stub"),
+                        owner = UserID("111"),
+                        syncControlRecord =  VDISyncControlRecord(
                             datasetID = DatasetID("12345678123456781234567812345678"),
                             sharesUpdated = UpdateTime,
                             dataUpdated = UpdateTime,
@@ -151,10 +157,10 @@ class ReconcilerTest {
         `when`(cacheDb.name).thenReturn("CacheDB")
         val datasetManager = mock<DatasetManager>()
         val kafkaRouter = mock<KafkaRouter>()
-        val recon = ReconcilerInstance(cacheDb, datasetManager, kafkaRouter)
+        val recon = ReconcilerInstance(cacheDb, datasetManager, kafkaRouter, false)
 
         `when`(cacheDb.streamSortedSyncControlRecords()).thenReturn(
-            closeableIterator(emptyList<Pair<VDIDatasetType, VDISyncControlRecord>>().iterator())
+            closeableIterator(emptyList<VDIReconcilerTargetRecord>().iterator())
         )
         doReturn(
             listOf(
@@ -167,124 +173,187 @@ class ReconcilerTest {
         assertEquals(3, mockingDetails(kafkaRouter).invocations.size)
     }
 
-//    @Test
-//    @DisplayName("Test delete one in the middle")
-//    fun test5() {
-//        val cacheDb = mock<ReconcilerTarget>()
-//        `when`(cacheDb.name).thenReturn("CacheDB")
-//        val datasetManager = mock<DatasetManager>()
-//        val kafkaRouter = mock<KafkaRouter>()
-//
-//        val recon = ReconcilerInstance(cacheDb, datasetManager, kafkaRouter)
-//
-//        `when`(cacheDb.streamSortedSyncControlRecords()).thenReturn(
-//            closeableIterator(listOf(
-//                Pair(
-//                    VDIDatasetTypeImpl("Stub", "Stub"), VDISyncControlRecord(
-//                        datasetID = DatasetID("12345678123456781234567812345678"),
-//                        sharesUpdated = UpdateTime,
-//                        dataUpdated = UpdateTime,
-//                        metaUpdated = UpdateTime
-//                    )
-//                ),
-//                Pair(
-//                    VDIDatasetTypeImpl("Stub", "Stub"), VDISyncControlRecord(
-//                        datasetID = DatasetID("22345678123456781234567812345678"),
-//                        sharesUpdated = UpdateTime,
-//                        dataUpdated = UpdateTime,
-//                        metaUpdated = UpdateTime
-//                    )
-//                ),
-//                Pair(
-//                    VDIDatasetTypeImpl("Stub", "Stub"), VDISyncControlRecord(
-//                        datasetID = DatasetID("32345678123456781234567812345678"),
-//                        sharesUpdated = UpdateTime,
-//                        dataUpdated = UpdateTime,
-//                        metaUpdated = UpdateTime
-//                    )
-//                ),
-//                Pair(
-//                    VDIDatasetTypeImpl("Stub", "Stub"), VDISyncControlRecord(
-//                        datasetID = DatasetID("42345678123456781234567812345678"),
-//                        sharesUpdated = UpdateTime,
-//                        dataUpdated = UpdateTime,
-//                        metaUpdated = UpdateTime
-//                    )
-//                )
-//            ).iterator())
-//        )
-//        doReturn(listOf(
-//            mockDatasetDirectory(111L, "12345678123456781234567812345678"),
-//            // Missing 22345678123456781234567812345678, should be deleted in target.
-//            mockDatasetDirectory(111L, "32345678123456781234567812345678"),
-//            mockDatasetDirectory(111L, "42345678123456781234567812345678"),
-//        ).stream()).`when`(datasetManager).streamAllDatasets()
-//        recon.reconcile()
-//        val capturedDatasetID = mockingDetails(cacheDb).invocations
-//            .find { it.method.name == "deleteDataset" }!!
-//            .getArgument<DatasetID>(1)
-//        assertEquals("test", "22345678123456781234567812345678", capturedDatasetID.toString())
-//    }
+    @Test
+    @DisplayName("Test delete dataset in middle of stream")
+    fun test5() {
+        val cacheDb = mock<ReconcilerTarget>()
+        `when`(cacheDb.name).thenReturn("CacheDB")
+        val datasetManager = mock<DatasetManager>()
+        val kafkaRouter = mock<KafkaRouter>()
+        val recon = ReconcilerInstance(cacheDb, datasetManager, kafkaRouter, false)
 
-//    @Test
-//    @DisplayName("Test delete last datasets in target stream, then sync last source")
-//    fun test6() {
-//        val cacheDb = mock<ReconcilerTarget>()
-//        `when`(cacheDb.name).thenReturn("CacheDB")
-//        val datasetManager = mock<DatasetManager>()
-//        val kafkaRouter = mock<KafkaRouter>()
-//        val recon = ReconcilerInstance(cacheDb, datasetManager, kafkaRouter)
-//
-//        `when`(cacheDb.type).thenReturn(ReconcilerTargetType.Cache)
-//
-//        `when`(cacheDb.streamSortedSyncControlRecords()).thenReturn(
-//            closeableIterator(listOf(
-//                Pair(
-//                    VDIDatasetTypeImpl("Stub", "Stub"), VDISyncControlRecord(
-//                        datasetID = DatasetID("22345678123456781234567812345678"),
-//                        sharesUpdated = UpdateTime,
-//                        dataUpdated = UpdateTime,
-//                        metaUpdated = UpdateTime
-//                    )
-//                ),
-//                Pair(
-//                    VDIDatasetTypeImpl("Stub", "Stub"), VDISyncControlRecord(
-//                        datasetID = DatasetID("32345678123456781234567812345678"),
-//                        sharesUpdated = UpdateTime,
-//                        dataUpdated = UpdateTime,
-//                        metaUpdated = UpdateTime
-//                    )
-//                ),
-//                Pair(
-//                    VDIDatasetTypeImpl("Stub", "Stub"), VDISyncControlRecord(
-//                        datasetID = DatasetID("42345678123456781234567812345678"),
-//                        sharesUpdated = UpdateTime,
-//                        dataUpdated = UpdateTime,
-//                        metaUpdated = UpdateTime
-//                    )
-//                ),
-//                ).iterator())
-//        )
-//        doReturn(listOf(
-//            mockDatasetDirectory(111L, "12345678123456781234567812345678", UpdateTime.plusDays(1)),
-//            mockDatasetDirectory(111L, "52345678123456781234567812345678", UpdateTime.plusDays(1)),
-//
-//            ).stream()).`when`(datasetManager).streamAllDatasets()
-//        recon.reconcile()
-//        val syncedIDs = mockingDetails(kafkaRouter).invocations
-//            .filter { it.method.name == "sendUpdateMetaTrigger" }
-//            .map { it.getArgument<UpdateMetaTrigger>(0).datasetID.toString() }
-//        val deletedIDs = mockingDetails(cacheDb).invocations
-//            .filter { it.method.name == "deleteDataset" }
-//            .map { it.getArgument<DatasetID>(1).toString() }
-//
-//        assertEquals(listOf("12345678123456781234567812345678", "52345678123456781234567812345678"), syncedIDs)
-//        assertEquals(listOf("22345678123456781234567812345678", "32345678123456781234567812345678", "42345678123456781234567812345678"), deletedIDs)
-//    }
+        `when`(cacheDb.streamSortedSyncControlRecords()).thenReturn(
+            closeableIterator(listOf(
+                VDIReconcilerTargetRecord(
+                    type = VDIDatasetTypeImpl("Stub", "Stub"),
+                    owner = UserID("111"),
+                    syncControlRecord = VDISyncControlRecord(
+                        datasetID = DatasetID("12345678123456781234567812345678"),
+                        sharesUpdated = UpdateTime,
+                        dataUpdated = UpdateTime,
+                        metaUpdated = UpdateTime
+                    )
+                ),
+                VDIReconcilerTargetRecord(
+                    type = VDIDatasetTypeImpl("Stub", "Stub"),
+                    owner = UserID("111"),
+                    syncControlRecord = VDISyncControlRecord(
+                        datasetID = DatasetID("22345678123456781234567812345678"),
+                        sharesUpdated = UpdateTime,
+                        dataUpdated = UpdateTime,
+                        metaUpdated = UpdateTime
+                    )
+                ),
+                VDIReconcilerTargetRecord(
+                    type = VDIDatasetTypeImpl("Stub", "Stub"),
+                    owner = UserID("111"),
+                    syncControlRecord = VDISyncControlRecord(
+                        datasetID = DatasetID("32345678123456781234567812345678"),
+                        sharesUpdated = UpdateTime,
+                        dataUpdated = UpdateTime,
+                        metaUpdated = UpdateTime
+                    )
+                ),
+                VDIReconcilerTargetRecord(
+                    type = VDIDatasetTypeImpl("Stub", "Stub"),
+                    owner = UserID("111"),
+                    syncControlRecord = VDISyncControlRecord(
+                        datasetID = DatasetID("42345678123456781234567812345678"),
+                        sharesUpdated = UpdateTime,
+                        dataUpdated = UpdateTime,
+                        metaUpdated = UpdateTime
+                    )
+                )
+            ).iterator())
+        )
+        doReturn(listOf(
+            mockDatasetDirectory(111L, "12345678123456781234567812345678"),
+            // Missing 22345678123456781234567812345678, should be deleted in target.
+            mockDatasetDirectory(111L, "32345678123456781234567812345678"),
+            mockDatasetDirectory(111L, "42345678123456781234567812345678"),
+        ).stream()).`when`(datasetManager).streamAllDatasets()
+        recon.reconcile()
+        val capturedDatasetID = mockingDetails(cacheDb).invocations
+            .find { it.method.name == "deleteDataset" }!!
+            .getArgument<DatasetID>(1)
+        assertEquals("test", "22345678123456781234567812345678", capturedDatasetID.toString())
+    }
 
     @Test
-    @DisplayName("Test case sensitivity")
+    @DisplayName("Test delete last datasets in target stream, then sync last source")
+    fun test6() {
+        val cacheDb = mock<ReconcilerTarget>()
+        `when`(cacheDb.name).thenReturn("CacheDB")
+        val datasetManager = mock<DatasetManager>()
+        val kafkaRouter = mock<KafkaRouter>()
+        val recon = ReconcilerInstance(cacheDb, datasetManager, kafkaRouter, false)
+
+        `when`(cacheDb.type).thenReturn(ReconcilerTargetType.Cache)
+
+        `when`(cacheDb.streamSortedSyncControlRecords()).thenReturn(
+            closeableIterator(listOf(
+                VDIReconcilerTargetRecord(
+                    type = VDIDatasetTypeImpl("Stub", "Stub"),
+                    owner = UserID("111"),
+                    syncControlRecord = VDISyncControlRecord(
+                        datasetID = DatasetID("22345678123456781234567812345678"),
+                        sharesUpdated = UpdateTime,
+                        dataUpdated = UpdateTime,
+                        metaUpdated = UpdateTime
+                    )
+                ),
+                VDIReconcilerTargetRecord(
+                    type = VDIDatasetTypeImpl("Stub", "Stub"),
+                    owner = UserID("111"),
+                    syncControlRecord = VDISyncControlRecord(
+                        datasetID = DatasetID("32345678123456781234567812345678"),
+                        sharesUpdated = UpdateTime,
+                        dataUpdated = UpdateTime,
+                        metaUpdated = UpdateTime
+                    )
+                ),
+                VDIReconcilerTargetRecord(
+                    type = VDIDatasetTypeImpl("Stub", "Stub"),
+                    owner = UserID("111"),
+                    syncControlRecord = VDISyncControlRecord(
+                        datasetID = DatasetID("42345678123456781234567812345678"),
+                        sharesUpdated = UpdateTime,
+                        dataUpdated = UpdateTime,
+                        metaUpdated = UpdateTime
+                    )
+                ),
+                ).iterator())
+        )
+        doReturn(listOf(
+            mockDatasetDirectory(111L, "12345678123456781234567812345678", UpdateTime.plusDays(1)),
+            mockDatasetDirectory(111L, "52345678123456781234567812345678", UpdateTime.plusDays(1)),
+
+            ).stream()).`when`(datasetManager).streamAllDatasets()
+        recon.reconcile()
+        val syncedIDs = mockingDetails(kafkaRouter).invocations
+            .filter { it.method.name == "sendUpdateMetaTrigger" }
+            .map { it.getArgument<UpdateMetaTrigger>(0).datasetID.toString() }
+        val deletedIDs = mockingDetails(cacheDb).invocations
+            .filter { it.method.name == "deleteDataset" }
+            .map { it.getArgument<DatasetID>(1).toString() }
+
+        assertEquals(listOf("12345678123456781234567812345678", "52345678123456781234567812345678"), syncedIDs)
+        assertEquals(listOf("22345678123456781234567812345678", "32345678123456781234567812345678", "42345678123456781234567812345678"), deletedIDs)
+    }
+
+    @Test
+    @DisplayName("Test different owners")
     fun test7() {
+        val cacheDb = mock<ReconcilerTarget>()
+        `when`(cacheDb.name).thenReturn("CacheDB")
+        val datasetManager = mock<DatasetManager>()
+        val kafkaRouter = mock<KafkaRouter>()
+        val recon = ReconcilerInstance(cacheDb, datasetManager, kafkaRouter, false)
+
+        `when`(cacheDb.type).thenReturn(ReconcilerTargetType.Cache)
+
+        `when`(cacheDb.streamSortedSyncControlRecords()).thenReturn(
+            closeableIterator(listOf(
+                VDIReconcilerTargetRecord(
+                    type = VDIDatasetTypeImpl("Stub", "Stub"),
+                    owner = UserID("111"),
+                    syncControlRecord = VDISyncControlRecord(
+                        datasetID = DatasetID("bbb"),
+                        sharesUpdated = UpdateTime,
+                        dataUpdated = UpdateTime,
+                        metaUpdated = UpdateTime
+                    )
+                ),
+                VDIReconcilerTargetRecord(
+                    type = VDIDatasetTypeImpl("Stub", "Stub"),
+                    owner = UserID("333"),
+                    syncControlRecord = VDISyncControlRecord(
+                        datasetID = DatasetID("aaa"),
+                        sharesUpdated = UpdateTime,
+                        dataUpdated = UpdateTime,
+                        metaUpdated = UpdateTime
+                    )
+                )
+            ).iterator())
+        )
+        doReturn(
+            listOf(
+                mockDatasetDirectory(111L, "bbb", UpdateTime),
+                mockDatasetDirectory(222L, "zzz", UpdateTime),
+                mockDatasetDirectory(333L, "aaa", UpdateTime),
+                ).stream()
+        ).`when`(datasetManager).streamAllDatasets()
+        recon.reconcile()
+        val deletedIDs = mockingDetails(cacheDb).invocations
+            .filter { it.method.name == "deleteDataset" }
+            .map { it.getArgument<DatasetID>(1).toString() }
+
+        assertEquals(listOf(), deletedIDs)
+    }
+
+
+    @DisplayName("Test case sensitivity")
+    fun test8() {
         val cacheDb = mock<ReconcilerTarget>()
         `when`(cacheDb.name).thenReturn("CacheDB")
         val datasetManager = mock<DatasetManager>()
@@ -295,8 +364,10 @@ class ReconcilerTest {
 
         `when`(cacheDb.streamSortedSyncControlRecords()).thenReturn(
             closeableIterator(listOf(
-                Pair(
-                    VDIDatasetTypeImpl("Stub", "Stub"), VDISyncControlRecord(
+                VDIReconcilerTargetRecord(
+                    type = VDIDatasetTypeImpl("Stub", "Stub"),
+                    owner = UserID("111"),
+                    syncControlRecord = VDISyncControlRecord(
                         datasetID = DatasetID("Vbz2OgjnKsR"),
                         sharesUpdated = UpdateTime,
                         dataUpdated = UpdateTime,
@@ -319,8 +390,8 @@ class ReconcilerTest {
         assertEquals(listOf(), deletedIDs)
     }
 
-    private fun closeableIterator(iterator: Iterator<Pair<VDIDatasetType, VDISyncControlRecord>>): CloseableIterator<Pair<VDIDatasetType, VDISyncControlRecord>> {
-        return object: CloseableIterator<Pair<VDIDatasetType, VDISyncControlRecord>> {
+    private fun closeableIterator(iterator: Iterator<VDIReconcilerTargetRecord>): CloseableIterator<VDIReconcilerTargetRecord> {
+        return object: CloseableIterator<VDIReconcilerTargetRecord> {
             override fun close() {
                 // do nothing
             }
@@ -329,7 +400,7 @@ class ReconcilerTest {
                 return iterator.hasNext()
             }
 
-            override fun next(): Pair<VDIDatasetType, VDISyncControlRecord> {
+            override fun next(): VDIReconcilerTargetRecord {
                 return iterator.next()
             }
         }

--- a/platform/build.gradle.kts
+++ b/platform/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
     api("org.veupathdb.lib:multipart-jackson-pojo:1.1.3")
 
     // VDI
-    api("org.veupathdb.vdi:vdi-component-common:6.6.1")
+    api("org.veupathdb.vdi:vdi-component-common:6.7.0")
     api("org.veupathdb.vdi:vdi-component-json:1.0.1")
 
     // Database


### PR DESCRIPTION
## Overview
* Fixed the sort to avoid deleting large swaths of data
* This was due to the owner ID not being included when comparing the streams in-memory