### PR TITLE
Fix dataset manager streaming API when datasets are malformed

### DIFF
--- a/components/s3/build.gradle.kts
+++ b/components/s3/build.gradle.kts
@@ -2,6 +2,10 @@ plugins {
   kotlin("jvm")
 }
 
+tasks.test {
+  useJUnitPlatform()
+}
+
 dependencies {
   implementation(platform(project(":platform")))
 

--- a/components/s3/src/test/kotlin/org/veupathdb/vdi/lib/s3/datasets/paths/IndexKtTest.kt
+++ b/components/s3/src/test/kotlin/org/veupathdb/vdi/lib/s3/datasets/paths/IndexKtTest.kt
@@ -24,7 +24,7 @@ class IndexKtTest {
       assertEquals("bucket", path.bucketName)
       assertEquals("vdi", path.rootSegment)
       assertEquals("111", path.userID.toString())
-      assertEquals("AA41EFE0A1B3EEB9BF303E4561FF8392", path.datasetID.toString())
+      assertEquals("aa41efe0a1b3eeb9bf303e4561ff8392", path.datasetID.toString())
       assertEquals("foo.txt", path.subPath)
     }
 
@@ -38,7 +38,7 @@ class IndexKtTest {
       assertEquals("bucket", path.bucketName)
       assertEquals("vdi", path.rootSegment)
       assertEquals("111", path.userID.toString())
-      assertEquals("AA41EFE0A1B3EEB9BF303E4561FF8392", path.datasetID.toString())
+      assertEquals("aa41efe0a1b3eeb9bf303e4561ff8392", path.datasetID.toString())
       assertEquals("foo.txt", path.subPath)
     }
 
@@ -52,7 +52,7 @@ class IndexKtTest {
       assertEquals("bucket", path.bucketName)
       assertEquals("vdi", path.rootSegment)
       assertEquals("111", path.userID.toString())
-      assertEquals("AA41EFE0A1B3EEB9BF303E4561FF8392", path.datasetID.toString())
+      assertEquals("aa41efe0a1b3eeb9bf303e4561ff8392", path.datasetID.toString())
       assertEquals("222", path.recipientID.toString())
       assertEquals("offer.json", path.subPath)
     }
@@ -67,7 +67,7 @@ class IndexKtTest {
       assertEquals("bucket", path.bucketName)
       assertEquals("vdi", path.rootSegment)
       assertEquals("111", path.userID.toString())
-      assertEquals("AA41EFE0A1B3EEB9BF303E4561FF8392", path.datasetID.toString())
+      assertEquals("aa41efe0a1b3eeb9bf303e4561ff8392", path.datasetID.toString())
       assertEquals("butt.xml", path.subPath)
     }
   }

--- a/components/s3/src/test/kotlin/org/veupathdb/vdi/lib/s3/datasets/paths/S3PathsTest.kt
+++ b/components/s3/src/test/kotlin/org/veupathdb/vdi/lib/s3/datasets/paths/S3PathsTest.kt
@@ -30,43 +30,43 @@ class S3PathsTest {
 
   @Test
   fun datasetDir() {
-    assertEquals("vdi/1/912EC803B2CE49E4A541068D495AB570/", S3Paths.datasetDir(USER_ID, DATASET_ID))
+    assertEquals("vdi/1/912ec803b2ce49e4a541068d495ab570/", S3Paths.datasetDir(USER_ID, DATASET_ID))
   }
 
   @Test
   fun datasetManifestFile() {
-    assertEquals("vdi/1/912EC803B2CE49E4A541068D495AB570/dataset/$DatasetManifestFilename", S3Paths.datasetManifestFile(USER_ID, DATASET_ID))
+    assertEquals("vdi/1/912ec803b2ce49e4a541068d495ab570/dataset/$DatasetManifestFilename", S3Paths.datasetManifestFile(USER_ID, DATASET_ID))
   }
 
   @Test
   fun datasetMetaFile() {
-    assertEquals("vdi/1/912EC803B2CE49E4A541068D495AB570/dataset/$DatasetMetaFilename", S3Paths.datasetMetaFile(USER_ID, DATASET_ID))
+    assertEquals("vdi/1/912ec803b2ce49e4a541068d495ab570/dataset/$DatasetMetaFilename", S3Paths.datasetMetaFile(USER_ID, DATASET_ID))
   }
 
   @Test
   fun datasetDeleteFlagFile() {
-    assertEquals("vdi/1/912EC803B2CE49E4A541068D495AB570/dataset/delete-flag", S3Paths.datasetDeleteFlagFile(USER_ID, DATASET_ID))
+    assertEquals("vdi/1/912ec803b2ce49e4a541068d495ab570/dataset/delete-flag", S3Paths.datasetDeleteFlagFile(USER_ID, DATASET_ID))
   }
 
   @Test
   fun datasetDataDir() {
-    assertEquals("vdi/1/912EC803B2CE49E4A541068D495AB570/dataset/data/", S3Paths.datasetDataDir(USER_ID, DATASET_ID))
+    assertEquals("vdi/1/912ec803b2ce49e4a541068d495ab570/dataset/data/", S3Paths.datasetDataDir(USER_ID, DATASET_ID))
   }
 
   @Test
   fun datasetDataFile() {
-    assertEquals("vdi/1/912EC803B2CE49E4A541068D495AB570/dataset/data/file.ext", S3Paths.datasetDataFile(USER_ID, DATASET_ID, FILE_NAME))
+    assertEquals("vdi/1/912ec803b2ce49e4a541068d495ab570/dataset/data/file.ext", S3Paths.datasetDataFile(USER_ID, DATASET_ID, FILE_NAME))
   }
 
   @Test
   fun datasetSharesDir() {
-    assertEquals("vdi/1/912EC803B2CE49E4A541068D495AB570/dataset/shares/", S3Paths.datasetSharesDir(USER_ID, DATASET_ID))
+    assertEquals("vdi/1/912ec803b2ce49e4a541068d495ab570/dataset/shares/", S3Paths.datasetSharesDir(USER_ID, DATASET_ID))
   }
 
   @Test
   fun datasetShareOfferFile() {
     assertEquals(
-      "vdi/1/912EC803B2CE49E4A541068D495AB570/dataset/shares/2/offer.json",
+      "vdi/1/912ec803b2ce49e4a541068d495ab570/dataset/shares/2/offer.json",
       S3Paths.datasetShareOfferFile(USER_ID, DATASET_ID, RECIPIENT_ID)
     )
   }
@@ -74,18 +74,18 @@ class S3PathsTest {
   @Test
   fun datasetShareReceiptFile() {
     assertEquals(
-      "vdi/1/912EC803B2CE49E4A541068D495AB570/dataset/shares/2/receipt.json",
+      "vdi/1/912ec803b2ce49e4a541068d495ab570/dataset/shares/2/receipt.json",
       S3Paths.datasetShareReceiptFile(USER_ID, DATASET_ID, RECIPIENT_ID)
     )
   }
 
   @Test
   fun datasetUploadsDir() {
-    assertEquals("vdi/1/912EC803B2CE49E4A541068D495AB570/upload/", S3Paths.datasetUploadsDir(USER_ID, DATASET_ID))
+    assertEquals("vdi/1/912ec803b2ce49e4a541068d495ab570/upload/", S3Paths.datasetUploadsDir(USER_ID, DATASET_ID))
   }
 
   @Test
   fun datasetUploadFile() {
-    assertEquals("vdi/1/912EC803B2CE49E4A541068D495AB570/upload/file.ext", S3Paths.datasetUploadFile(USER_ID, DATASET_ID, FILE_NAME))
+    assertEquals("vdi/1/912ec803b2ce49e4a541068d495ab570/upload/file.ext", S3Paths.datasetUploadFile(USER_ID, DATASET_ID, FILE_NAME))
   }
 }


### PR DESCRIPTION
## Overview
Fixing the malformed dataset handling in stream API. This change attempts to make the stream API resilient to malformed datasets, logging them and noting them along the way.