### PR TITLE
Share event handler rewrite.

### DIFF
--- a/components/cache-db/src/main/kotlin/org/veupathdb/vdi/lib/db/cache/model/DatasetShare.kt
+++ b/components/cache-db/src/main/kotlin/org/veupathdb/vdi/lib/db/cache/model/DatasetShare.kt
@@ -6,6 +6,6 @@ import org.veupathdb.vdi.lib.common.model.VDIShareReceiptAction
 
 data class DatasetShare(
   val recipientID: UserID,
-  val offerStatus: VDIShareOfferAction,
-  val receiptStatus: VDIShareReceiptAction,
+  val offerStatus: VDIShareOfferAction?,
+  val receiptStatus: VDIShareReceiptAction?,
 )

--- a/components/cache-db/src/main/kotlin/org/veupathdb/vdi/lib/db/cache/sql/select/select-dataset-shares.kt
+++ b/components/cache-db/src/main/kotlin/org/veupathdb/vdi/lib/db/cache/sql/select/select-dataset-shares.kt
@@ -15,7 +15,7 @@ SELECT
 , dsr.status AS receipt_status
 FROM
   vdi.dataset_share_offers AS dso
-  LEFT JOIN vdi.dataset_share_receipts AS dsr
+  FULL OUTER JOIN vdi.dataset_share_receipts AS dsr
     USING (dataset_id, recipient_id)
 WHERE
   dataset_id = ?
@@ -28,8 +28,8 @@ internal fun Connection.selectSharesFor(datasetID: DatasetID) =
       map {
         DatasetShare(
           recipientID   = it.getUserID("recipient_id"),
-          offerStatus   = VDIShareOfferAction.fromString(it.getString("offer_status")),
-          receiptStatus = it.getString("receipt_status")?.let(VDIShareReceiptAction::fromString) ?: VDIShareReceiptAction.Accept
+          offerStatus   = it.getString("offer_status")?.let(VDIShareOfferAction::fromString),
+          receiptStatus = it.getString("receipt_status")?.let(VDIShareReceiptAction::fromString)
         )
       }
     }

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -88,8 +88,6 @@ services:
     - minio-external
     - minio-create-buckets
     links:
-    - cache-db
-    - kafka
     - rabbit-external
     - minio-external
     networks:

--- a/modules/event-router/src/main/kotlin/vdi/module/events/routing/EventRouterImpl.kt
+++ b/modules/event-router/src/main/kotlin/vdi/module/events/routing/EventRouterImpl.kt
@@ -91,7 +91,7 @@ internal class EventRouterImpl(private val config: EventRouterConfig) : EventRou
         // remove everything.  This event should be one of many for this
         // specific dataset.
         event.eventType.action == MinIOEventAction.DELETE -> {
-          log.debug("received a hard delete event for dataset {} owned by user {} for MinIO key {}", path.datasetID.toString(), path.userID.toString(), event.objectKey)
+          log.debug("received a hard delete event for dataset {}/{} for MinIO key {}", path.userID.toString(), path.datasetID.toString(), event.objectKey)
 
           safeSend(HardDeleteTrigger(path.userID, path.datasetID), kr::sendHardDeleteTrigger)
         }
@@ -100,14 +100,14 @@ internal class EventRouterImpl(private val config: EventRouterConfig) : EventRou
         // only ever put something in the upload directory when the dataset is
         // first uploaded by the client.
         path is VDUploadPath -> {
-          log.debug("received an import event for dataset {} owned by user {}", path.datasetID, path.userID)
+          log.debug("received an import event for dataset {}/{}", path.userID, path.datasetID)
 
           safeSend(ImportTrigger(path.userID, path.datasetID), kr::sendImportTrigger)
         }
 
         // If the meta file was updated...
         path is VDDatasetFilePath && path.subPath == DatasetMetaFilename -> {
-          log.debug("received an metadata event for dataset {} owned by user {}", path.datasetID, path.userID)
+          log.debug("received an metadata event for dataset {}/{}", path.userID, path.datasetID)
 
           safeSend(UpdateMetaTrigger(path.userID, path.datasetID), kr::sendUpdateMetaTrigger)
           safeSend(ImportTrigger(path.userID, path.datasetID), kr::sendImportTrigger)
@@ -116,21 +116,21 @@ internal class EventRouterImpl(private val config: EventRouterConfig) : EventRou
         // If the path was to a soft delete flag then we have a soft-delete
         // event.
         path is VDDatasetFilePath && path.subPath == S3Paths.DELETE_FLAG_FILE_NAME -> {
-          log.debug("received a soft delete event for dataset {} owned by user {}", path.datasetID, path.userID)
+          log.debug("received a soft delete event for dataset {}/{}", path.userID, path.datasetID)
 
           safeSend(SoftDeleteTrigger(path.userID, path.datasetID), kr::sendSoftDeleteTrigger)
         }
 
         // If the path is to a share file then we have a share event.
         path is VDDatasetShareFilePath -> {
-          log.debug("received a share event for dataset {} owned by user {}", path.datasetID, path.userID)
+          log.debug("received a share event for dataset {}/{}", path.userID, path.datasetID)
 
           safeSend(ShareTrigger(path.userID, path.datasetID), kr::sendShareTrigger)
         }
 
         // Else, we have an install event.
         else                                              -> {
-          log.debug("received an install event for dataset {} owned by user {}", path.datasetID, path.userID)
+          log.debug("received an install event for dataset {}/{}", path.userID, path.datasetID)
 
           safeSend(InstallTrigger(path.userID, path.datasetID), kr::sendInstallTrigger)
         }

--- a/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/service/datasets/get-dataset-by-id.kt
+++ b/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/service/datasets/get-dataset-by-id.kt
@@ -69,7 +69,7 @@ fun getDatasetByID(userID: UserID, datasetID: DatasetID): DatasetDetails {
   }
 
   // Lookup user details for the dataset's owner and any share users
-  val userDetails = AccountDB.lookupUserDetails(HashSet<UserID>(shares.size + 1)
+  val userDetails = AccountDB.lookupUserDetails(HashSet<UserID>(shares.size + 2)
     .apply {
       add(userID)
       add(dataset.ownerID)
@@ -113,10 +113,11 @@ fun getDatasetByID(userID: UserID, datasetID: DatasetID): DatasetDetails {
     }
 
     shares.forEach { share ->
-      out.shares.add(ShareOffer(
-        userDetails[share.recipientID] ?: throw IllegalStateException("no user details for share recipient"),
-        share.offerStatus
-      ))
+      if (share.offerStatus != null)
+        out.shares.add(ShareOffer(
+          userDetails[share.recipientID] ?: throw IllegalStateException("no user details for share recipient"),
+          share.offerStatus!!
+        ))
     }
   }
 }

--- a/modules/share-trigger-handler/src/main/kotlin/vdi/module/handler/share/trigger/ShareTriggerHandlerImpl.kt
+++ b/modules/share-trigger-handler/src/main/kotlin/vdi/module/handler/share/trigger/ShareTriggerHandlerImpl.kt
@@ -195,7 +195,7 @@ internal class ShareTriggerHandlerImpl(private val config: ShareTriggerHandlerCo
       // Iterate through all the shares that appear in S3...
       shares.forEach { (shareRecipientUserID, shareDetails) ->
 
-        // Figure out what the state of the shares are in S3 (what file exist
+        // Figure out what the state of the shares are in S3 (what files exist
         // and what they say).
         val shareState = computeShareState(shareDetails)
 
@@ -315,17 +315,17 @@ internal class ShareTriggerHandlerImpl(private val config: ShareTriggerHandlerCo
           log.debug("removing dataset {}/{} visibility from user {} as per S3 share state", dataset.ownerID, dataset.datasetID, shareRecipient)
           db.deleteDatasetVisibility(dataset.datasetID, shareRecipient)
         }
-
-        // All the visibility records remaining in the recipient ID set from the
-        // target app database are invalid as they have no matching records in
-        // S3.  Purge them from the target app database.
-        visibilityRecords.forEach { recipientUserID ->
-          log.debug("removing dataset {}/{} visibility from user {} as S3 contains no such share", dataset.ownerID, dataset.datasetID, shareRecipient)
-          db.deleteDatasetVisibility(dataset.datasetID, recipientUserID)
-        }
-
-        db.updateSyncControlSharesTimestamp(dataset.datasetID, latestShareTimestamp)
       }
+
+      // All the visibility records remaining in the recipient ID set from the
+      // target app database are invalid as they have no matching records in S3.
+      // Purge them from the target app database.
+      visibilityRecords.forEach { recipientUserID ->
+        log.debug("removing dataset {}/{} visibility from user {} as S3 contains no such share", dataset.ownerID, dataset.datasetID, shareRecipient)
+        db.deleteDatasetVisibility(dataset.datasetID, recipientUserID)
+      }
+
+      db.updateSyncControlSharesTimestamp(dataset.datasetID, latestShareTimestamp)
     }
   }
 

--- a/modules/share-trigger-handler/src/main/kotlin/vdi/module/handler/share/trigger/ShareTriggerHandlerImpl.kt
+++ b/modules/share-trigger-handler/src/main/kotlin/vdi/module/handler/share/trigger/ShareTriggerHandlerImpl.kt
@@ -321,7 +321,7 @@ internal class ShareTriggerHandlerImpl(private val config: ShareTriggerHandlerCo
       // target app database are invalid as they have no matching records in S3.
       // Purge them from the target app database.
       visibilityRecords.forEach { recipientUserID ->
-        log.debug("removing dataset {}/{} visibility from user {} as S3 contains no such share", dataset.ownerID, dataset.datasetID, shareRecipient)
+        log.debug("removing dataset {}/{} visibility from user {} as S3 contains no such share", dataset.ownerID, dataset.datasetID, recipientUserID)
         db.deleteDatasetVisibility(dataset.datasetID, recipientUserID)
       }
 

--- a/modules/share-trigger-handler/src/main/kotlin/vdi/module/handler/share/trigger/ShareTriggerHandlerImpl.kt
+++ b/modules/share-trigger-handler/src/main/kotlin/vdi/module/handler/share/trigger/ShareTriggerHandlerImpl.kt
@@ -12,8 +12,10 @@ import org.veupathdb.vdi.lib.common.model.VDIShareOfferAction
 import org.veupathdb.vdi.lib.common.model.VDIShareReceiptAction
 import org.veupathdb.vdi.lib.common.util.isNull
 import org.veupathdb.vdi.lib.db.app.AppDB
+import org.veupathdb.vdi.lib.db.app.AppDBTransaction
 import org.veupathdb.vdi.lib.db.app.AppDatabaseRegistry
 import org.veupathdb.vdi.lib.db.cache.CacheDB
+import org.veupathdb.vdi.lib.db.cache.model.DatasetRecord
 import org.veupathdb.vdi.lib.db.cache.model.DatasetShareOfferImpl
 import org.veupathdb.vdi.lib.db.cache.model.DatasetShareReceiptImpl
 import org.veupathdb.vdi.lib.kafka.model.triggers.ShareTrigger
@@ -22,11 +24,30 @@ import org.veupathdb.vdi.lib.s3.datasets.DatasetShare
 import vdi.component.modules.VDIServiceModuleBase
 import java.sql.SQLException
 import java.time.OffsetDateTime
+import org.veupathdb.vdi.lib.s3.datasets.DatasetShare as S3Share
 
+private const val UniqueConstraintViolation = 1
+
+private enum class ShareState { Yes, No, Absent }
+
+private data class ShareInfo(
+  val offer: ShareState,
+  val receipt: ShareState,
+) {
+  inline val visibleInTarget
+    get() = offer == ShareState.Yes && receipt == ShareState.Yes
+}
+
+/**
+ * Share Trigger Event Handler
+ *
+ * This trigger handler processes trigger events for dataset shares being
+ * created or removed.
+ */
 internal class ShareTriggerHandlerImpl(private val config: ShareTriggerHandlerConfig)
-  : ShareTriggerHandler
-  , VDIServiceModuleBase("share-trigger-handler")
-{
+: ShareTriggerHandler
+, VDIServiceModuleBase("share-trigger-handler") {
+
   private val log = LoggerFactory.getLogger(javaClass)
 
   override suspend fun run() {
@@ -39,7 +60,7 @@ internal class ShareTriggerHandlerImpl(private val config: ShareTriggerHandlerCo
         while (!isShutDown()) {
           kc.fetchMessages(config.shareTriggerMessageKey, ShareTrigger::class)
             .forEach { (userID, datasetID) ->
-              log.debug("submitting job to share worker pool for user {}, dataset {}", userID, datasetID)
+              log.debug("submitting job to share worker pool for dataset {}/{}", datasetID, userID)
               wp.submit { executeJob(userID, datasetID, dm) }
             }
         }
@@ -54,132 +75,296 @@ internal class ShareTriggerHandlerImpl(private val config: ShareTriggerHandlerCo
   }
 
   private fun executeJob(userID: UserID, datasetID: DatasetID, dm: DatasetManager) {
-    log.trace("executeJob(userID={}, datasetID={}, dm=...)", userID, datasetID)
+    log.info("processing share trigger for dataset {}/{}", userID, datasetID)
 
-    with(CacheDB.selectDataset(datasetID)) {
-      if (isNull() || isDeleted)
-        return
+    val dataset = CacheDB.selectDataset(datasetID)
+
+    // If the dataset record is null, then no such dataset exists in the cache
+    // database, which is weird because the dataset record is written to the
+    // cache database synchronously when the dataset is initially submitted.
+    if (dataset.isNull()) {
+      log.warn("target dataset {}/{} does not exist in the internal cache database, skipping event", userID, datasetID)
+      return
     }
 
-    log.debug("looking up dataset directory for user {}, dataset {}", userID, datasetID)
+    if (dataset.isDeleted) {
+      log.info("target dataset {}/{} is marked as deleted in the internal cache database", userID, datasetID)
+      purgeFromTargets(dataset)
+      return
+    }
+
+    log.debug("looking up dataset directory for dataset {}/{}", userID, datasetID)
     val dir = dm.getDatasetDirectory(userID, datasetID)
 
-    val syncControl = CacheDB.selectSyncControl(datasetID)
+    val cacheDBSyncControl = CacheDB.selectSyncControl(datasetID)
 
-    if (syncControl == null) {
-      log.debug("skipping share event for dataset {} (user {}): dataset does not yet have a sync control record", datasetID, userID)
+    if (cacheDBSyncControl == null) {
+      log.info("skipping share event for dataset {}/{}: dataset does not yet have a sync control record", userID, datasetID)
       return
     }
-
-    val shareTimestamp = dir.getLatestShareTimestamp(syncControl.sharesUpdated)
-
-    if (!shareTimestamp.isAfter(syncControl.sharesUpdated)) {
-      log.debug("skipping share event for dataset {} (user {}): already up to date", datasetID, userID)
-      return
-    }
-
-    CacheDB.withTransaction { it.updateShareSyncControl(datasetID, shareTimestamp) }
 
     if (!dir.isImportComplete()) {
-      log.debug("skipping share event for dataset {} (user {}): dataset is not import complete", datasetID, userID)
+      log.info("skipping share event for dataset {}/{}: dataset is not import complete", userID, datasetID)
       return
     }
 
-    val meta = dir.getMeta().load()!!
+    val latestShareFileTimestamp = dir.getLatestShareTimestamp(cacheDBSyncControl.sharesUpdated)
 
-    dir.getShares()
-      .forEach { (recipientID, share) -> processShare(userID, datasetID, recipientID, meta.projects, share, shareTimestamp) }
+    // If the newest file version in MinIO has a timestamp that is newer than
+    // the timestamp recorded in the postgres cache database, the share is brand
+    // new and the share should be synchronized for all target projects.
+    if (latestShareFileTimestamp.isAfter(cacheDBSyncControl.sharesUpdated)) {
+      synchronizeAll(dataset, dir.getShares(), latestShareFileTimestamp)
+    }
+
+    // Else, if the newest file version in MinIO has a timestamp that is equal
+    // to (or somehow before?) the timestamp that appears in the cache db, check
+    // each individual project to make sure everything is up-to-date.
+    //
+    // A dataset could be out of sync in a single project if the project was
+    // temporarily disabled, added later, was externally modified, or is being
+    // rebuilt.
+    else {
+      synchronizeWhereNeeded(dataset, dir.getShares(), latestShareFileTimestamp)
+    }
   }
 
-  private fun processShare(
-    userID:         UserID,
-    datasetID:      DatasetID,
-    recipientID:    UserID,
-    projects:       Iterable<ProjectID>,
-    share:          DatasetShare,
-    shareTimestamp: OffsetDateTime,
+  private fun synchronizeAll(
+    dataset: DatasetRecord,
+    shares: Map<UserID, S3Share>,
+    latestShareTimestamp: OffsetDateTime
   ) {
-    val offer   = share.offer.load()
-    val receipt = share.receipt.load()
-
-    // There is no offer object in S3.  As it may have previously existed
-    // and been deleted, we will go through and make sure we clear out any
-    // possible records that would allow the recipient user to still see the
-    // dataset.
-    if (offer == null) {
-      cleanupAppDBs(datasetID, recipientID, projects, shareTimestamp)
-
-      // Remove the offer record from the cache db.
-      CacheDB.withTransaction {
-        it.deleteShareOffer(datasetID, recipientID)
-      }
-    } else {
-      CacheDB.withTransaction {
-        it.upsertDatasetShareOffer(DatasetShareOfferImpl(datasetID, recipientID, offer.action))
-      }
+    synchronizeCacheDB(dataset, shares, latestShareTimestamp)
+    dataset.projects.forEach { projectID ->
+      if (projectID in AppDatabaseRegistry)
+        synchronizeProject(projectID, dataset, shares, latestShareTimestamp)
+      else
+        log.info("dataset {}/{} target {} is not currently enabled, skipping share sync", dataset.ownerID, dataset.datasetID, projectID)
     }
+  }
 
-    // There is no receipt object in S3.  As it may have previously existed
-    // and been deleted, we will go through and make sure we clear out any
-    // possible records that would allow the recipient user to still see the
-    // dataset.
-    if (receipt == null) {
-      cleanupAppDBs(datasetID, recipientID, projects, shareTimestamp)
+  private fun synchronizeWhereNeeded(
+    dataset: DatasetRecord,
+    shares: Map<UserID, S3Share>,
+    latestShareTimestamp: OffsetDateTime
+  ) {
+    dataset.projects.forEach {
+      val targetDB = AppDB.accessor(it)
 
-      // Remove the receipt record from the cache DB.
-      CacheDB.withTransaction {
-        it.deleteShareReceipt(datasetID, recipientID)
+      if (targetDB == null) {
+        log.info("dataset {}/{} target {} is not currently enabled, skipping share sync", dataset.ownerID, dataset.datasetID, it)
+        return@forEach
       }
-    } else {
-      CacheDB.withTransaction {
-        it.upsertDatasetShareReceipt(DatasetShareReceiptImpl(datasetID, recipientID, receipt.action))
+
+      val targetSyncControl = targetDB.selectDatasetSyncControlRecord(dataset.datasetID)
+
+      if (targetSyncControl == null) {
+        log.info("dataset {}/{} has never been synchronized with target {}, skipping share sync", dataset.ownerID, dataset.datasetID, it)
+        return@forEach
       }
-    }
 
-    // If we have both the offer and receipt objects in S3, then we can
-    // check the share status and decide whether the dataset should be
-    // visible for the recipient user.
-    if (offer != null && receipt != null) {
-      if (offer.action == VDIShareOfferAction.Grant && receipt.action == VDIShareReceiptAction.Accept) {
-        for (projectID in projects) {
-          if (projectID !in AppDatabaseRegistry) {
-            log.info("Skipping share update for dataset {}/{}, project {} due to target project config being disabled.", userID, datasetID, projectID)
-            continue
-          }
-
-          AppDB.withTransaction(projectID) {
-            it.updateSyncControlSharesTimestamp(datasetID, shareTimestamp)
-            try {
-              it.insertDatasetVisibility(datasetID, recipientID)
-            } catch (e: SQLException) {
-              // swallow unique constraint violations
-              if (e.errorCode != 1) {
-                throw e
-              }
-            }
-          }
-        }
+      if (latestShareTimestamp.isAfter(targetSyncControl.sharesUpdated)) {
+        synchronizeProject(it, dataset, shares, latestShareTimestamp)
       } else {
-        cleanupAppDBs(datasetID, recipientID, projects, shareTimestamp)
+        log.info("dataset {}/{} is up to date in target {}, skipping share sync", dataset.ownerID, dataset.datasetID, it)
       }
     }
   }
 
-  private fun cleanupAppDBs(
-    datasetID: DatasetID,
-    recipientID: UserID,
-    projects: Iterable<ProjectID>,
-    shareTimestamp: OffsetDateTime
+  private fun synchronizeCacheDB(
+    dataset: DatasetRecord,
+    shares: Map<UserID, DatasetShare>,
+    latestShareTimestamp: OffsetDateTime,
   ) {
-    for (project in projects) {
-      if (project !in AppDatabaseRegistry) {
-        log.info("Cannot clean up target app database for project {} as the target project config is disabled.", project)
-        continue
+    log.info("processing shares for dataset {}/{} in internal cache database", dataset.ownerID, dataset.datasetID)
+
+    // Get a set of all the share recipients for all the shares attached to this
+    // dataset in the internal cache db.
+    //
+    // This set will be used to track all the share records that appear in the
+    // internal cache DB that do not appear in S3.  Records will be removed from
+    // this set as shares from S3 are processed, leaving only those share
+    // records that no longer appear in S3.
+    val cachedShares = CacheDB.selectSharesForDataset(dataset.datasetID)
+      .asSequence()
+      .map { it.recipientID }
+      .toMutableSet()
+
+    CacheDB.withTransaction { db ->
+
+      // Iterate through all the shares that appear in S3...
+      shares.forEach { (shareRecipientUserID, shareDetails) ->
+
+        // Figure out what the state of the shares are in S3 (what file exist
+        // and what they say).
+        val shareState = computeShareState(shareDetails)
+
+        // Process the share offer.  If S3 has a share offer file present, the
+        // share offer action will be recorded in the internal cache database.
+        // If S3 does not have a share offer file present, any share offer
+        // record in the internal cache db will be removed.
+        when (shareState.offer) {
+          ShareState.Yes -> db.upsertDatasetShareOffer(
+            DatasetShareOfferImpl(
+              dataset.datasetID,
+              shareRecipientUserID,
+              VDIShareOfferAction.Grant
+            )
+          )
+
+          ShareState.No -> db.upsertDatasetShareOffer(
+            DatasetShareOfferImpl(
+              dataset.datasetID,
+              shareRecipientUserID,
+              VDIShareOfferAction.Revoke
+            )
+          )
+
+          ShareState.Absent -> db.deleteShareOffer(dataset.datasetID, shareRecipientUserID)
+        }
+
+        // Process the share receipt.  If S3 has a share receipt file present,
+        // the share receipt action will be recorded in the internal cache
+        // database.  If S3 does not have a share receipt file present, any
+        // share receipt record in the internal cache db will be removed.
+        when (shareState.receipt) {
+          ShareState.Yes -> db.upsertDatasetShareReceipt(
+            DatasetShareReceiptImpl(
+              dataset.datasetID,
+              shareRecipientUserID,
+              VDIShareReceiptAction.Accept
+            )
+          )
+
+          ShareState.No -> db.upsertDatasetShareReceipt(
+            DatasetShareReceiptImpl(
+              dataset.datasetID,
+              shareRecipientUserID,
+              VDIShareReceiptAction.Reject
+            )
+          )
+
+          ShareState.Absent -> db.deleteShareReceipt(dataset.datasetID, shareRecipientUserID)
+        }
+
+        // We have processed the share details for the current recipient user.
+        // Remove it from the cached shares set so that we don't purge it from
+        // the database.
+        cachedShares.remove(shareRecipientUserID)
       }
 
-      AppDB.withTransaction(project) {
-        it.updateSyncControlSharesTimestamp(datasetID, shareTimestamp)
-        it.deleteDatasetVisibility(datasetID, recipientID)
+      // For all cached shares remaining in the set, purge them from the
+      // internal cache database.
+      cachedShares.forEach { shareRecipientUserID ->
+        db.deleteShareOffer(dataset.datasetID, shareRecipientUserID)
+        db.deleteShareReceipt(dataset.datasetID, shareRecipientUserID)
+      }
+
+      // Finally, update the sync control record.
+      db.updateShareSyncControl(dataset.datasetID, latestShareTimestamp)
+    }
+  }
+
+  private fun synchronizeProject(
+    projectID: ProjectID,
+    dataset: DatasetRecord,
+    shares: Map<UserID, S3Share>,
+    latestShareTimestamp: OffsetDateTime,
+  ) {
+    log.info("processing shares for dataset {}/{} in project {}", dataset.ownerID, dataset.datasetID, projectID)
+
+    AppDB.withTransaction(projectID) { db ->
+      // Get a set of the recipient user IDs for all the users that this
+      // dataset has been shared with in the target database.
+      //
+      // This set will be used to track all the visibility records that appear
+      // in the app DB that do not appear in S3.  Recipient user IDs will be
+      // removed from this set as shares from S3 are processed, leaving only
+      // those visibility/share records that no longer appear in S3.
+      val visibilityRecords = db.selectDatasetVisibilityRecords(dataset.datasetID)
+        .asSequence()
+        .map { it.userID }
+        .toMutableSet()
+
+      // For all the shares (complete or partial) that appear in S3...
+      shares.forEach { (shareRecipient, shareDetails) ->
+        log.debug("examining share for dataset {}/{} to user {}", dataset.ownerID, dataset.datasetID, shareRecipient)
+
+        // Figure out what's going on with the share, as in what share files
+        // exist and what the files that do exist say.
+        val shareState = computeShareState(shareDetails)
+
+        // Remove the current recipient user id from the app db and cache db
+        // record caches.
+        visibilityRecords.remove(shareRecipient)
+
+        // If the dataset should be visible to the recipient user as
+        // determined by examining the S3 share state, attempt to insert a
+        // visibility record.  Since a visibility record may have already
+        // existed, or been created by a competing worker, unique constraint
+        // violations will be ignored on insert.
+        if (shareState.visibleInTarget) {
+          log.debug("ensuring dataset {}/{} is visible to user {}", dataset.ownerID, dataset.datasetID, shareRecipient)
+          db.tryInsertDatasetVisibility(dataset.ownerID, dataset.datasetID, shareRecipient)
+        }
+
+        // If the dataset should not be visible to the recipient user as
+        // determined by examining the S3 share state, attempt to remove any
+        // existing visibility record.
+        else {
+          log.debug("removing dataset {}/{} visibility from user {} as per S3 share state", dataset.ownerID, dataset.datasetID, shareRecipient)
+          db.deleteDatasetVisibility(dataset.datasetID, shareRecipient)
+        }
+
+        // All the visibility records remaining in the recipient ID set from the
+        // target app database are invalid as they have no matching records in
+        // S3.  Purge them from the target app database.
+        visibilityRecords.forEach { recipientUserID ->
+          log.debug("removing dataset {}/{} visibility from user {} as S3 contains no such share", dataset.ownerID, dataset.datasetID, shareRecipient)
+          db.deleteDatasetVisibility(dataset.datasetID, recipientUserID)
+        }
+
+        db.updateSyncControlSharesTimestamp(dataset.datasetID, latestShareTimestamp)
+      }
+    }
+  }
+
+  private fun purgeFromTargets(dataset: DatasetRecord) {
+    log.info("purging dataset visibility records for dataset {}/{} from all target projects", dataset.ownerID, dataset.datasetID)
+
+    dataset.projects.forEach { projectID ->
+
+      if (projectID !in AppDatabaseRegistry) {
+        log.debug("cannot purge dataset visibility records for dataset {}/{} from project {} as that target is not currently enabled", dataset.ownerID, dataset.datasetID, projectID)
+        return@forEach
+      }
+
+      AppDB.withTransaction(projectID) { db -> db.deleteDatasetVisibilities(dataset.datasetID) }
+    }
+  }
+
+  private fun computeShareState(shareDetails: S3Share) =
+    ShareInfo(
+      offer = when (shareDetails.offer.load()?.action) {
+        null                       -> ShareState.Absent
+        VDIShareOfferAction.Grant  -> ShareState.Yes
+        VDIShareOfferAction.Revoke -> ShareState.No
+      },
+      receipt = when (shareDetails.receipt.load()?.action) {
+        null                         -> ShareState.Absent
+        VDIShareReceiptAction.Accept -> ShareState.Yes
+        VDIShareReceiptAction.Reject -> ShareState.No
+      },
+    )
+
+  private fun AppDBTransaction.tryInsertDatasetVisibility(ownerID: UserID, datasetID: DatasetID, recipientID: UserID) {
+    try {
+      insertDatasetVisibility(datasetID, recipientID)
+    } catch (e: SQLException) {
+      if (e.errorCode == UniqueConstraintViolation) {
+        log.debug("share insert race condition: dataset {}/{} already shared with {}", ownerID, datasetID, recipientID)
+      } else {
+        throw e
       }
     }
   }

--- a/modules/update-meta-trigger-handler/src/main/kotlin/vdi/module/handler/meta/triggers/UpdateMetaTriggerHandlerImpl.kt
+++ b/modules/update-meta-trigger-handler/src/main/kotlin/vdi/module/handler/meta/triggers/UpdateMetaTriggerHandlerImpl.kt
@@ -129,12 +129,12 @@ internal class UpdateMetaTriggerHandlerImpl(private val config: UpdateMetaTrigge
     comparison(dir, syncControl, userID, datasetID)
       .also {
         if (it.doDataSync) {
-          log.info("Doing little reconciliation data sync")
+          log.info("doing little reconciliation data sync for dataset {}/{}", userID, datasetID)
           kr.sendInstallTrigger(InstallTrigger(userID, datasetID))
         }
 
         if (it.doShareSync) {
-          log.info("Doing little reconciliation share sync")
+          log.info("doing little reconciliation share sync for dataset {}/{}", userID, datasetID)
           kr.sendShareTrigger(ShareTrigger(userID, datasetID))
         }
       }
@@ -422,8 +422,8 @@ internal class UpdateMetaTriggerHandlerImpl(private val config: UpdateMetaTrigge
     for (project in dataset.projects) {
       val appDB = AppDB.accessor(project)
       if (appDB == null) {
-        log.info("Skipping dataset state comparison for dataset {}/{}, project {} due to the target project config being disabled.", userID, datasetID, project)
-        return SyncActions(doShareSync = false, doDataSync = false)
+        log.info("skipping dataset state comparison for dataset {}/{}, project {} due to the target project config being disabled.", userID, datasetID, project)
+        continue
       }
 
       log.debug("checking project {} for dataset {}/{} to see if it is out of sync", project, userID, datasetID)


### PR DESCRIPTION
The initial implementation of the share event handler only checked the sync control record in the internal postgres cache database to determine whether shares were out of sync.  This lead to issues where datasets were removed/readded or altered in the target database but their shares were no longer synchronized because the share event handler never checked the target database's sync control record.

This rewrite attempts to resolve that by having the handler check every one of the dataset's target projects' sync control records to ensure the shares are up to date regardless of whether the postgres cache db's sync control record is up to date.

---

In addition to the above changes, an unrelated share issue was located in the user dataset details endpoint call tree where datasets with a share receipt but no share offer would not be included in the result output.  This is an edge case that will likely never happen, but should be handled to provide as much detail as possible about the state of a dataset.