### PR TITLE
Lowercase dataset type name

### DIFF
--- a/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/sql/insert-dataset.kt
+++ b/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/sql/insert-dataset.kt
@@ -23,7 +23,7 @@ internal fun Connection.insertDataset(schema: String, dataset: DatasetRecord) {
     .use { ps ->
       ps.setString(1, dataset.datasetID.toString())
       ps.setLong(2, dataset.owner.toLong())
-      ps.setString(3, dataset.typeName)
+      ps.setString(3, dataset.typeName.lowercase())
       ps.setString(4, dataset.typeVersion)
       ps.setBoolean(5, dataset.isDeleted)
       ps.executeUpdate()

--- a/components/cache-db/src/main/kotlin/org/veupathdb/vdi/lib/db/cache/sql/insert/insert-dataset.kt
+++ b/components/cache-db/src/main/kotlin/org/veupathdb/vdi/lib/db/cache/sql/insert/insert-dataset.kt
@@ -37,7 +37,7 @@ internal fun Connection.tryInsertDatasetRecord(
 ) =
   preparedUpdate(SQL) {
     setDatasetID(1, datasetID)
-    setString(2, typeName)
+    setString(2, typeName.lowercase())
     setString(3, typeVersion)
     setUserID(4, ownerID)
     setBoolean(5, isDeleted)

--- a/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/generated/model/x-DatasetTypeInfo.kt
+++ b/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/generated/model/x-DatasetTypeInfo.kt
@@ -2,25 +2,22 @@ package org.veupathdb.service.vdi.generated.model
 
 import org.veupathdb.vdi.lib.common.model.VDIDatasetType
 import org.veupathdb.vdi.lib.db.cache.model.DatasetRecord
+import org.veupathdb.vdi.lib.handler.mapping.PluginHandlers
 
 
 internal fun DatasetTypeInfo(rec: DatasetRecord, typeName: String): DatasetTypeInfo =
-  DatasetTypeInfoImpl().also {
-    it.name = rec.typeName
-    it.version = rec.typeVersion
-    it.displayName = typeName
-  }
+  DatasetTypeInfo(rec.typeName, rec.typeVersion, typeName)
 
 internal fun DatasetTypeInfo(info: VDIDatasetType, displayName: String): DatasetTypeInfo =
-  DatasetTypeInfoImpl().also {
-    it.name = info.name
-    it.version = info.version
-    it.displayName = displayName
-  }
+  DatasetTypeInfo(info.name, info.version, displayName)
 
 internal fun DatasetTypeInfo(name: String, version: String, displayName: String): DatasetTypeInfo =
   DatasetTypeInfoImpl().also {
-    it.name = name
+    it.name = name.lowercase()
     it.version = version
     it.displayName = displayName
   }
+
+internal fun DatasetTypeInfo(name: String, version: String): DatasetTypeInfo =
+  DatasetTypeInfo(name, version, PluginHandlers[name, version]?.displayName
+      ?: throw IllegalStateException("missing dataset type name"))

--- a/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/generated/model/x-DatasetTypeInfo.kt
+++ b/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/generated/model/x-DatasetTypeInfo.kt
@@ -20,4 +20,4 @@ internal fun DatasetTypeInfo(name: String, version: String, displayName: String)
 
 internal fun DatasetTypeInfo(name: String, version: String): DatasetTypeInfo =
   DatasetTypeInfo(name, version, PluginHandlers[name, version]?.displayName
-      ?: throw IllegalStateException("missing dataset type name"))
+      ?: throw IllegalStateException("missing plugin handler for plugin $name $version"))

--- a/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/server/controllers/VDIDatasetFilesController.kt
+++ b/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/server/controllers/VDIDatasetFilesController.kt
@@ -43,7 +43,6 @@ class VDIDatasetFilesController(@Context request: ContainerRequest) : VdiDataset
           .headersFor200()
           .withContentDisposition("attachment; filename=\"$datasetID-upload.zip\"")
       )
-
   }
 
   @AllowAdminAuth

--- a/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/server/controllers/VDIUsersController.kt
+++ b/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/server/controllers/VDIUsersController.kt
@@ -13,5 +13,4 @@ class VDIUsersController(@Context request: ContainerRequest) : VdiUsers, Control
   override fun getVdiUsersSelfMeta(): VdiUsers.GetVdiUsersSelfMetaResponse {
     return VdiUsers.GetVdiUsersSelfMetaResponse.respond200WithApplicationJson(getUserMetadata(userID.toUserID()))
   }
-
 }

--- a/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/service/admin/list-all-datasets.kt
+++ b/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/service/admin/list-all-datasets.kt
@@ -99,11 +99,3 @@ private fun AllDatasetsListEntry(
     it.status = DatasetStatusInfo(row.importStatus, statuses)
     it.created = row.created.defaultZone()
   }
-
-private fun DatasetTypeInfo(name: String, version: String): DatasetTypeInfo =
-  DatasetTypeInfoImpl().also {
-    it.name = name
-    it.version = version
-    it.displayName = PluginHandlers[name, version]?.displayName
-      ?: throw IllegalStateException("missing dataset type name")
-  }

--- a/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/service/datasets/create-dataset.kt
+++ b/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/service/datasets/create-dataset.kt
@@ -188,7 +188,7 @@ private fun verifyFileSize(file: Path, userID: UserID) {
 private fun DatasetPostRequest.toDatasetMeta(userID: UserID) =
   VDIDatasetMetaImpl(
     type         = VDIDatasetTypeImpl(
-      name    = meta.datasetType.name,
+      name    = meta.datasetType.name.lowercase(),
       version = meta.datasetType.version,
     ),
     projects     = meta.projects.toSet(),

--- a/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/service/datasets/list-broken.kt
+++ b/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/service/datasets/list-broken.kt
@@ -103,16 +103,7 @@ private fun DatasetRecord.toDetails(
   BrokenDatasetDetailsImpl().also { out ->
     out.datasetId   = datasetID.toString()
     out.owner       = owner.toLong()
-    out.datasetType = getTypeInfo()
+    out.datasetType = DatasetTypeInfo(typeName, typeVersion)
     out.projectIds  = projects.toList()
     out.status      = DatasetStatusInfo(DatasetImportStatus.Complete, statuses)
   }
-
-private fun DatasetRecord.getTypeInfo(): DatasetTypeInfo {
-  return DatasetTypeInfo(
-    typeName,
-    typeVersion,
-    PluginHandlers[typeName, typeVersion]?.displayName
-      ?: throw IllegalStateException("plugin type missing: ${typeName}:${typeVersion}")
-  )
-}

--- a/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/service/shares/get-shares.kt
+++ b/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/service/shares/get-shares.kt
@@ -53,7 +53,7 @@ private fun convertToOutType(shares: Collection<DatasetShareListEntry>): List<Sh
     ShareOfferEntry(
       datasetID              = it.datasetID,
       shareStatus            = ShareFilterStatus.Open,
-      datasetTypeName        = it.typeName,
+      datasetTypeName        = it.typeName.lowercase(),
       datasetTypeVersion     = it.typeVersion,
       datasetTypeDisplayName = typeDisplayName,
       owner                  = owners[it.ownerID] ?: throw IllegalStateException("unknown dataset owner ${it.ownerID}"),


### PR DESCRIPTION
Ensure the dataset type name is in lowercase when:
1. Returned to the API client
2. Written to MinIO
3. Written to the internal postgres cache DB
4. Written to the target app DBs

Preexisting datasets that have type names with capitalization can stay as they are.  Their type name will be converted to lowercase when going out the door.

Resolves #187