### PR TITLE
Dataset Uninstall and Pruning Fix

### DIFF
--- a/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/AppDBTransaction.kt
+++ b/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/AppDBTransaction.kt
@@ -7,6 +7,7 @@ import org.veupathdb.vdi.lib.common.OriginTimestamp
 import org.veupathdb.vdi.lib.common.model.VDISyncControlRecord
 import org.veupathdb.vdi.lib.db.app.model.DatasetInstallMessage
 import org.veupathdb.vdi.lib.db.app.model.DatasetRecord
+import org.veupathdb.vdi.lib.db.app.model.DeleteFlag
 import org.veupathdb.vdi.lib.db.app.model.InstallType
 import java.time.OffsetDateTime
 
@@ -210,7 +211,7 @@ interface AppDBTransaction : AppDBAccessor, AutoCloseable {
    *
    * @param deleted The new value for the deleted flag.
    */
-  fun updateDatasetDeletedFlag(datasetID: DatasetID, deleted: Boolean)
+  fun updateDatasetDeletedFlag(datasetID: DatasetID, deleteFlag: DeleteFlag)
 
   /**
    * Updates the "data" last updated field on a target dataset sync control

--- a/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/AppDBTransactionImpl.kt
+++ b/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/AppDBTransactionImpl.kt
@@ -111,9 +111,9 @@ class AppDBTransactionImpl(
     connection.updateDataset(schema, dataset)
   }
 
-  override fun updateDatasetDeletedFlag(datasetID: DatasetID, deleted: Boolean) {
-    log.debug("updating dataset record deleted flag for dataset {} to {}", datasetID, deleted)
-    connection.updateDatasetDeletedFlag(schema, datasetID, deleted)
+  override fun updateDatasetDeletedFlag(datasetID: DatasetID, deleteFlag: DeleteFlag) {
+    log.debug("updating dataset record deleted flag for dataset {} to {}", datasetID, deleteFlag)
+    connection.updateDatasetDeletedFlag(schema, datasetID, deleteFlag)
   }
 
   override fun updateSyncControlDataTimestamp(datasetID: DatasetID, timestamp: OffsetDateTime) {

--- a/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/model/DatasetRecord.kt
+++ b/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/model/DatasetRecord.kt
@@ -31,5 +31,5 @@ data class DatasetRecord(
   /**
    * Whether the dataset has been marked as deleted.
    */
-  val isDeleted: Boolean,
+  val isDeleted: DeleteFlag,
 )

--- a/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/model/DeleteFlag.kt
+++ b/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/model/DeleteFlag.kt
@@ -1,0 +1,20 @@
+package org.veupathdb.vdi.lib.db.app.model
+
+enum class DeleteFlag(val value: Int) {
+  NotDeleted(0),
+  DeletedNotUninstalled(1),
+  DeletedAndUninstalled(2),
+  ;
+
+  companion object {
+
+    @JvmStatic
+    fun fromInt(value: Int): DeleteFlag {
+      for (enumValue in entries)
+        if (value == enumValue.value)
+          return enumValue
+
+      throw IllegalArgumentException("unrecognized DeleteFlag value: $value")
+    }
+  }
+}

--- a/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/model/DeleteFlag.kt
+++ b/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/model/DeleteFlag.kt
@@ -1,9 +1,42 @@
 package org.veupathdb.vdi.lib.db.app.model
 
+/**
+ * Dataset Deletion Status Indicator
+ *
+ * This enum represents the different deletion statuses a dataset may be in for
+ * install target App databases.
+ *
+ * Datasets that are marked with [NotDeleted] (`0` in the database) are visible
+ * to App DB queries for user datasets and may be included in results.
+ *
+ * Datasets that are marked with [DeletedNotUninstalled] (`2` in the database)
+ * or [DeletedAndUninstalled] (`3` in the database) are not visible to App DB
+ * queries.
+ *
+ * The flow of deletion statuses is:
+ *
+ * 1. [NotDeleted] - This is the initial status that is set when a dataset is
+ *    first registered in a target App DB.
+ * 2. [DeletedNotUninstalled] - This is the status that is set immediately when
+ *    a dataset deletion event is fired by the dataset owner.  This status means
+ *    the dataset should not be visible in App DB queries, but has not yet had
+ *    its data purged/uninstalled.
+ * 3. [DeletedAndUninstalled] - This status is set after the dataset data has
+ *    been successfully purged/uninstalled.  Datasets in this status are subject
+ *    to hard deletion at some point in the future.
+ *
+ * The integer value representing the statuses does not change in incrementing
+ * order as one may expect, it instead moves from `0` to `2` to `1`.  This is to
+ * maintain backwards compatibility with previous iterations of the VDI service,
+ * where there were only two statuses.  In those VDI versions, a dataset would
+ * only be set to the status `1` after a successful uninstall.  This created an
+ * issue, however, where datasets that a user had marked as deleted would still
+ * appear in App DB queries if the uninstall process for that dataset failed.
+ */
 enum class DeleteFlag(val value: Int) {
   NotDeleted(0),
-  DeletedNotUninstalled(1),
-  DeletedAndUninstalled(2),
+  DeletedNotUninstalled(2),
+  DeletedAndUninstalled(1),
   ;
 
   companion object {

--- a/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/sql/insert-dataset.kt
+++ b/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/sql/insert-dataset.kt
@@ -25,7 +25,7 @@ internal fun Connection.insertDataset(schema: String, dataset: DatasetRecord) {
       ps.setLong(2, dataset.owner.toLong())
       ps.setString(3, dataset.typeName.lowercase())
       ps.setString(4, dataset.typeVersion)
-      ps.setBoolean(5, dataset.isDeleted)
+      ps.setInt(5, dataset.isDeleted.value)
       ps.executeUpdate()
     }
 }

--- a/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/sql/select-dataset.kt
+++ b/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/sql/select-dataset.kt
@@ -3,6 +3,7 @@ package org.veupathdb.vdi.lib.db.app.sql
 import org.veupathdb.vdi.lib.common.field.DatasetID
 import org.veupathdb.vdi.lib.common.field.UserID
 import org.veupathdb.vdi.lib.db.app.model.DatasetRecord
+import org.veupathdb.vdi.lib.db.app.model.DeleteFlag
 import java.sql.Connection
 
 private fun sql(schema: String) =
@@ -32,7 +33,7 @@ internal fun Connection.selectDataset(schema: String, datasetID: DatasetID): Dat
         owner       = UserID(rs.getLong("owner")),
         typeName    = rs.getString("type_name"),
         typeVersion = rs.getString("type_version"),
-        isDeleted   = rs.getBoolean("is_deleted"),
+        isDeleted   = DeleteFlag.fromInt(rs.getInt("is_deleted")),
       )
     }
   }

--- a/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/sql/select-datasets-by-install-status.kt
+++ b/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/sql/select-datasets-by-install-status.kt
@@ -3,6 +3,7 @@ package org.veupathdb.vdi.lib.db.app.sql
 import org.veupathdb.vdi.lib.common.field.DatasetID
 import org.veupathdb.vdi.lib.common.field.UserID
 import org.veupathdb.vdi.lib.db.app.model.DatasetRecord
+import org.veupathdb.vdi.lib.db.app.model.DeleteFlag
 import org.veupathdb.vdi.lib.db.app.model.InstallStatus
 import org.veupathdb.vdi.lib.db.app.model.InstallType
 import java.sql.Connection
@@ -46,7 +47,7 @@ internal fun Connection.selectDatasetsByInstallStatus(
           owner       = UserID(rs.getLong("owner")),
           typeName    = rs.getString("type_name"),
           typeVersion = rs.getString("type_version"),
-          isDeleted   = rs.getBoolean("is_deleted"),
+          isDeleted   = DeleteFlag.fromInt(rs.getInt("is_deleted")),
         ))
       } while (rs.next())
 

--- a/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/sql/update-dataset-deleted-flag.kt
+++ b/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/sql/update-dataset-deleted-flag.kt
@@ -1,6 +1,7 @@
 package org.veupathdb.vdi.lib.db.app.sql
 
 import org.veupathdb.vdi.lib.common.field.DatasetID
+import org.veupathdb.vdi.lib.db.app.model.DeleteFlag
 import java.sql.Connection
 
 private fun sql(schema: String) =
@@ -14,10 +15,10 @@ WHERE
   dataset_id = ?
 """
 
-internal fun Connection.updateDatasetDeletedFlag(schema: String, datasetID: DatasetID, isDeleted: Boolean) {
+internal fun Connection.updateDatasetDeletedFlag(schema: String, datasetID: DatasetID, deleteFlag: DeleteFlag) {
   prepareStatement(sql(schema))
     .use { ps ->
-      ps.setBoolean(1, isDeleted)
+      ps.setInt(1, deleteFlag.value)
       ps.setString(2, datasetID.toString())
       ps.executeUpdate()
     }

--- a/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/sql/update-dataset.kt
+++ b/components/app-db/src/main/kotlin/org/veupathdb/vdi/lib/db/app/sql/update-dataset.kt
@@ -23,7 +23,7 @@ internal fun Connection.updateDataset(schema: String, dataset: DatasetRecord) {
       ps.setLong(1, dataset.owner.toLong())
       ps.setString(2, dataset.typeName)
       ps.setString(3, dataset.typeVersion)
-      ps.setBoolean(4, dataset.isDeleted)
+      ps.setInt(4, dataset.isDeleted.value)
       ps.setString(5, dataset.datasetID.toString())
       ps.executeUpdate()
     }

--- a/components/cache-db/src/main/kotlin/org/veupathdb/vdi/lib/db/cache/model/DeletedDataset.kt
+++ b/components/cache-db/src/main/kotlin/org/veupathdb/vdi/lib/db/cache/model/DeletedDataset.kt
@@ -1,9 +1,11 @@
 package org.veupathdb.vdi.lib.db.cache.model
 
 import org.veupathdb.vdi.lib.common.field.DatasetID
+import org.veupathdb.vdi.lib.common.field.ProjectID
 import org.veupathdb.vdi.lib.common.field.UserID
 
 data class DeletedDataset(
   val datasetID: DatasetID,
   val ownerID: UserID,
+  val projects: List<ProjectID>,
 )

--- a/modules/import-trigger-handler/src/main/kotlin/vdi/module/handler/imports/triggers/ImportTriggerHandlerImpl.kt
+++ b/modules/import-trigger-handler/src/main/kotlin/vdi/module/handler/imports/triggers/ImportTriggerHandlerImpl.kt
@@ -108,7 +108,7 @@ internal class ImportTriggerHandlerImpl(private val config: ImportTriggerHandler
     }
 
     try {
-      processImportJob(dm, userID, datasetID, datasetDir)
+      processImportJob(userID, datasetID, datasetDir)
     } finally {
       lock.withLock {
         activeIDs.remove(datasetID)
@@ -116,7 +116,7 @@ internal class ImportTriggerHandlerImpl(private val config: ImportTriggerHandler
     }
   }
 
-  private fun processImportJob(dm: DatasetManager, userID: UserID, datasetID: DatasetID, datasetDir: DatasetDirectory) {
+  private fun processImportJob(userID: UserID, datasetID: DatasetID, datasetDir: DatasetDirectory) {
     // Load the dataset metadata from S3
     val datasetMeta = datasetDir.getMeta().load()!!
 

--- a/modules/install-trigger-handler/src/main/kotlin/vdi/module/handler/install/data/InstallDataTriggerHandlerImpl.kt
+++ b/modules/install-trigger-handler/src/main/kotlin/vdi/module/handler/install/data/InstallDataTriggerHandlerImpl.kt
@@ -16,6 +16,7 @@ import org.veupathdb.vdi.lib.common.field.UserID
 import org.veupathdb.vdi.lib.common.fs.TempFiles
 import org.veupathdb.vdi.lib.db.app.AppDB
 import org.veupathdb.vdi.lib.db.app.model.DatasetInstallMessage
+import org.veupathdb.vdi.lib.db.app.model.DeleteFlag
 import org.veupathdb.vdi.lib.db.app.model.InstallStatus
 import org.veupathdb.vdi.lib.db.app.model.InstallType
 import org.veupathdb.vdi.lib.db.cache.CacheDB
@@ -193,7 +194,7 @@ internal class InstallDataTriggerHandlerImpl(private val config: InstallTriggerH
       return
     }
 
-    if (dataset.isDeleted) {
+    if (dataset.isDeleted != DeleteFlag.NotDeleted) {
       log.info("skipping install event for dataset {}/{} into project {} due to the dataset being marked as deleted", userID, datasetID, projectID)
       return
     }

--- a/modules/soft-delete-trigger-handler/src/main/kotlin/vdi/module/handler/delete/soft/SoftDeleteTriggerHandlerImpl.kt
+++ b/modules/soft-delete-trigger-handler/src/main/kotlin/vdi/module/handler/delete/soft/SoftDeleteTriggerHandlerImpl.kt
@@ -8,18 +8,18 @@ import org.veupathdb.vdi.lib.common.async.WorkerPool
 import org.veupathdb.vdi.lib.common.field.DatasetID
 import org.veupathdb.vdi.lib.common.field.ProjectID
 import org.veupathdb.vdi.lib.common.field.UserID
-import org.veupathdb.vdi.lib.common.model.VDIDatasetMeta
 import org.veupathdb.vdi.lib.db.app.AppDB
-import org.veupathdb.vdi.lib.db.app.model.InstallStatus
+import org.veupathdb.vdi.lib.db.app.AppDatabaseRegistry
+import org.veupathdb.vdi.lib.db.app.model.DeleteFlag
 import org.veupathdb.vdi.lib.db.cache.CacheDB
 import org.veupathdb.vdi.lib.db.cache.model.DatasetImportStatus
+import org.veupathdb.vdi.lib.db.cache.model.DatasetRecord
 import org.veupathdb.vdi.lib.handler.client.PluginHandlerClient
 import org.veupathdb.vdi.lib.handler.client.response.uni.UninstallBadRequestResponse
 import org.veupathdb.vdi.lib.handler.client.response.uni.UninstallResponseType
 import org.veupathdb.vdi.lib.handler.client.response.uni.UninstallUnexpectedErrorResponse
 import org.veupathdb.vdi.lib.handler.mapping.PluginHandlers
 import org.veupathdb.vdi.lib.kafka.model.triggers.SoftDeleteTrigger
-import org.veupathdb.vdi.lib.s3.datasets.DatasetManager
 import vdi.component.metrics.Metrics
 import vdi.component.modules.VDIServiceModuleBase
 
@@ -31,7 +31,6 @@ internal class SoftDeleteTriggerHandlerImpl(private val config: SoftDeleteTrigge
 
   override suspend fun run() {
     val kc = requireKafkaConsumer(config.softDeleteTriggerTopic, config.kafkaConsumerConfig)
-    val dm = DatasetManager(requireS3Bucket(requireS3Client(config.s3Config), config.s3Bucket))
     val wp = WorkerPool("soft-delete-workers", config.workQueueSize.toInt(), config.workerPoolSize.toInt())
 
     runBlocking {
@@ -40,7 +39,7 @@ internal class SoftDeleteTriggerHandlerImpl(private val config: SoftDeleteTrigge
           kc.fetchMessages(config.softDeleteTriggerMessageKey, SoftDeleteTrigger::class)
             .forEach { (userID, datasetID) ->
               log.info("received uninstall job for dataset $datasetID, user $userID")
-              wp.submit { runJob(userID, datasetID, dm) }
+              wp.submit { runJob(userID, datasetID) }
             }
         }
 
@@ -53,125 +52,112 @@ internal class SoftDeleteTriggerHandlerImpl(private val config: SoftDeleteTrigge
     confirmShutdown()
   }
 
-  private fun runJob(userID: UserID, datasetID: DatasetID, dm: DatasetManager) {
-    // Fetch the dataset directory from S3
-    val dir = dm.getDatasetDirectory(userID, datasetID)
+  private fun runJob(userID: UserID, datasetID: DatasetID) {
+    val internalDBRecord = CacheDB.selectDataset(datasetID)
+      ?: throw IllegalStateException("received uninstall event for a dataset that does not exist in the internal database")
 
-    // If the directory doesn't exist, then something has gone terribly wrong.
-    if (!dir.exists())
-      throw IllegalStateException("got an uninstall event for non-existent dataset $datasetID (user $userID)")
+    // Mark the dataset is deleted in the internal postgres database regardless
+    // of whether the uninstalls from the dataset's install targets succeed.
+    CacheDB.withTransaction { it.updateDatasetDeleted(datasetID, true) }
 
-    // Load the dataset metadata from S3
-    val meta = dir.getMeta().load()
-      ?: throw IllegalStateException("got an uninstall event for a dataset that has no meta file: dataset $datasetID, user $userID")
-
+    // If the dataset failed import, then nothing was installed into the
+    // dataset's install targets.
     if (!datasetIsImported(datasetID)) {
-      log.info("received uninstall event for a dataset that was not imported or failed import: {}/{}", userID, datasetID)
+      log.info("dataset {}/{} was not imported, no uninstalls necessary", userID, datasetID)
       return
     }
 
     val timer = Metrics.uninstallationTimes
-      .labels(meta.type.name, meta.type.version)
+      .labels(internalDBRecord.typeName, internalDBRecord.typeVersion)
       .startTimer()
 
-    // Grab a handler instance for this dataset type.
-    val handler = PluginHandlers.get(meta.type.name, meta.type.version)
-      ?: throw IllegalStateException("got an uninstall event for a dataset type that has no associated handler.  dataset $datasetID, user $userID")
+    // Grab a plugin handler instance for this dataset type.
+    val handler = PluginHandlers[internalDBRecord.typeName, internalDBRecord.typeVersion]
 
-    // Iterate through the projects that the metadata is targeting and call
-    // the uninstall path on each.
-    meta.projects.forEach { projectID ->
-      if (!handler.appliesToProject(projectID)) {
-        log.warn("type handler for type {} does not apply to project {} (dataset {}, user {})", handler.type, projectID, datasetID, userID)
-        return@forEach
-      }
-
-      val datasetInstalled = datasetIsInstalled(datasetID, projectID)
-
-      if (datasetInstalled == DatasetInstallStatus.Unknown) {
-        log.info("skipping uninstall event for dataset {}/{}, project {} as the target is disabled", userID, datasetID, projectID)
-        return@forEach
-      }
-
-      if (datasetInstalled == DatasetInstallStatus.NotInstalled) {
-        log.info("skipping uninstall event for dataset {}/{}, project {} as it is not installed", userID, datasetID, projectID)
-        return@forEach
-      }
-
-      runJob(userID, datasetID, projectID, handler.client, meta)
+    if (handler == null) {
+      log.error("no plugin handler found for dataset {}/{} type {}:{}", userID, datasetID, internalDBRecord.typeName, internalDBRecord.typeVersion)
+      return
     }
 
-    // Mark the dataset as deleted in the cache DB
-    CacheDB.withTransaction { it.updateDatasetDeleted(datasetID, true) }
+    // Iterate through the install targets for the dataset and attempt an
+    // uninstall on each.
+    internalDBRecord.projects.forEach { projectID ->
+      if (!handler.appliesToProject(projectID)) {
+        log.warn("type handler for dataset type {}:{} does not apply to project {} (dataset {}/{})", internalDBRecord.typeName, internalDBRecord.typeVersion, projectID, userID, datasetID)
+        return@forEach
+      }
+
+      if (projectID !in AppDatabaseRegistry) {
+        log.warn("dataset {}/{} cannot be uninstalled from target project {} as the project is disabled", userID, datasetID, projectID)
+        return@forEach
+      }
+
+      if (datasetShouldBeUninstalled(userID, datasetID, projectID)) {
+        try {
+          tryUninstallDataset(userID, datasetID, projectID, handler.client, internalDBRecord)
+        } catch (e: Throwable) {
+          log.error("dataset ${userID}/${projectID} uninstall from project $projectID failed: ", e)
+        }
+      }
+    }
 
     timer.observeDuration()
   }
 
-  private fun runJob(
-    userID:    UserID,
+  private fun tryUninstallDataset(
+    userID: UserID,
     datasetID: DatasetID,
     projectID: ProjectID,
-    handler:   PluginHandlerClient,
-    meta:      VDIDatasetMeta,
+    handler: PluginHandlerClient,
+    record: DatasetRecord
   ) {
+    AppDB.withTransaction(projectID) { it.updateDatasetDeletedFlag(datasetID, DeleteFlag.DeletedNotUninstalled) }
+
     val response = handler.postUninstall(datasetID, projectID)
 
-    Metrics.uninstallations.labels(meta.type.name, meta.type.version, response.responseCode.toString()).inc()
+    Metrics.uninstallations.labels(record.typeName, record.typeVersion, response.responseCode.toString()).inc()
 
     when (response.type) {
       UninstallResponseType.Success
       -> handleSuccessResponse(userID, datasetID, projectID)
 
       UninstallResponseType.BadRequest
-      -> handleBadRequestResponse(datasetID, projectID, response as UninstallBadRequestResponse)
+      -> handleBadRequestResponse(userID, datasetID, projectID, response as UninstallBadRequestResponse)
 
       UninstallResponseType.UnexpectedError
-      -> handleUnexpectedErrorResponse(datasetID, projectID, response as UninstallUnexpectedErrorResponse)
+      -> handleUnexpectedErrorResponse(userID, datasetID, projectID, response as UninstallUnexpectedErrorResponse)
     }
+  }
+
+  private fun datasetShouldBeUninstalled(userID: UserID, datasetID: DatasetID, projectID: ProjectID): Boolean {
+    val dataset = AppDB.accessor(projectID)!!.selectDataset(datasetID)
+
+    if (dataset == null) {
+      log.warn("dataset {}/{} does not appear in target project {}, cannot run uninstall", userID, datasetID, projectID)
+      return false
+    }
+
+    if (dataset.isDeleted == DeleteFlag.DeletedAndUninstalled) {
+      log.info("dataset {}/{} has already been successfully uninstalled from target project {}", userID, datasetID, projectID)
+      return false
+    }
+
+    return true
   }
 
   private fun handleSuccessResponse(userID: UserID, datasetID: DatasetID, projectID: ProjectID) {
-    log.info("dataset handler server reports dataset {} was successfully uninstalled from project {}", datasetID, projectID)
-
-    val appDB = try {
-      AppDB.transaction(projectID)!!
-    } catch (e: Throwable) {
-      throw IllegalStateException("dataset $datasetID (user $userID) is linked to project $projectID which is currently unknown to the vdi service", e)
-    }
-
-    try {
-      appDB.updateDatasetDeletedFlag(datasetID, true)
-      appDB.commit()
-    } catch (e: Throwable) {
-      log.error("failed to update dataset deleted flag for dataset $datasetID (user $userID)", e)
-      appDB.rollback()
-      return
-    } finally {
-      appDB.close()
-    }
+    log.info("dataset handler server reports dataset {}/{} was successfully uninstalled from project {}", userID, datasetID, projectID)
+    AppDB.withTransaction(projectID) { it.updateDatasetDeletedFlag(datasetID, DeleteFlag.DeletedAndUninstalled) }
   }
 
-  private fun handleBadRequestResponse(datasetID: DatasetID, projectID: ProjectID, res: UninstallBadRequestResponse) {
-    log.error("dataset handler server reports 400 error for uninstall on dataset {}, project {}", datasetID, projectID)
+  private fun handleBadRequestResponse(userID: UserID, datasetID: DatasetID, projectID: ProjectID, res: UninstallBadRequestResponse) {
+    log.error("dataset handler server reports 400 error for uninstall on dataset {}/{}, project {}", userID, datasetID, projectID)
     throw IllegalStateException(res.message)
   }
 
-  private fun handleUnexpectedErrorResponse(datasetID: DatasetID, projectID: ProjectID, res: UninstallUnexpectedErrorResponse) {
-    log.error("dataset handler server reports 500 for uninstall on dataset {}, project {}", datasetID, projectID)
+  private fun handleUnexpectedErrorResponse(userID: UserID, datasetID: DatasetID, projectID: ProjectID, res: UninstallUnexpectedErrorResponse) {
+    log.error("dataset handler server reports 500 for uninstall on dataset {}/{}, project {}", userID, datasetID, projectID)
     throw IllegalStateException(res.message)
-  }
-
-  private enum class DatasetInstallStatus { Installed, NotInstalled, Unknown }
-
-  private fun datasetIsInstalled(datasetID: DatasetID, projectID: ProjectID): DatasetInstallStatus {
-    val appDB = AppDB.accessor(projectID) ?: return DatasetInstallStatus.Unknown
-
-    for (message in appDB.selectDatasetInstallMessages(datasetID)) {
-      if (message.status == InstallStatus.Complete)
-        return DatasetInstallStatus.Installed
-    }
-
-    return DatasetInstallStatus.NotInstalled
   }
 
   private fun datasetIsImported(datasetID: DatasetID): Boolean {

--- a/modules/update-meta-trigger-handler/src/main/kotlin/vdi/module/handler/meta/triggers/UpdateMetaTriggerHandlerImpl.kt
+++ b/modules/update-meta-trigger-handler/src/main/kotlin/vdi/module/handler/meta/triggers/UpdateMetaTriggerHandlerImpl.kt
@@ -15,10 +15,7 @@ import org.veupathdb.vdi.lib.common.model.VDISyncControlRecord
 import org.veupathdb.vdi.lib.common.util.or
 import org.veupathdb.vdi.lib.db.app.AppDB
 import org.veupathdb.vdi.lib.db.app.AppDBTransaction
-import org.veupathdb.vdi.lib.db.app.model.DatasetInstallMessage
-import org.veupathdb.vdi.lib.db.app.model.DatasetRecord
-import org.veupathdb.vdi.lib.db.app.model.InstallStatus
-import org.veupathdb.vdi.lib.db.app.model.InstallType
+import org.veupathdb.vdi.lib.db.app.model.*
 import org.veupathdb.vdi.lib.db.cache.CacheDB
 import org.veupathdb.vdi.lib.db.cache.CacheDBTransaction
 import org.veupathdb.vdi.lib.db.cache.model.DatasetImpl
@@ -207,7 +204,7 @@ internal class UpdateMetaTriggerHandlerImpl(private val config: UpdateMetaTrigge
             owner       = meta.owner,
             typeName    = meta.type.name,
             typeVersion = meta.type.version,
-            isDeleted   = false
+            isDeleted   = DeleteFlag.NotDeleted,
           ))
 
           it.insertDatasetVisibility(datasetID, meta.owner)


### PR DESCRIPTION
* Changes the usage of the app db `is_deleted` field to be a 3-state enum value rather than a boolean flag.
* Updates the dataset soft-delete/uninstallation lane to:
    * Always update the deletion flag in the internal postgres database regardless of whether the app db uninstall(s) succeeded.
    * Update the `is_deleted` flag in the target app database(s) to a new value that indicates a delete was attempted or is in progress.  This value will hide the dataset from the dataset availability view in the app database(s)
    * On successful uninstall, update the `is_deleted` flag in the target app database to a new value that indicates the delete succeeded.  This value will also hide the dataset from the dataset availability view in the app database(s)
* Updated the pruner to check all dataset install targets to ensure that the dataset was successfully uninstalled from all of them before deleting from MinIO