### PR TITLE
Add queue metrics and don't show shares if import failed

### DIFF
--- a/components/cache-db/src/main/kotlin/org/veupathdb/vdi/lib/db/cache/sql/select/select-dataset-shares-list.kt
+++ b/components/cache-db/src/main/kotlin/org/veupathdb/vdi/lib/db/cache/sql/select/select-dataset-shares-list.kt
@@ -14,12 +14,15 @@ SELECT
 , dso.recipient_id
 , dso.status AS offer_status
 , dsr.status AS receipt_status
+, ds.
 FROM
   unnest(?) AS ids(dataset_id)
   INNER JOIN vdi.dataset_share_offers AS dso
     USING (dataset_id)
   LEFT JOIN vdi.dataset_share_receipts AS dsr
     USING (dataset_id, recipient_id)
+  LEFT JOIN vdi.datasets AS ds
+    USING (dataset_id)
 """
 
 internal fun Connection.selectSharesFor(datasetIDs: List<DatasetID>): Map<DatasetID, List<DatasetShare>> {

--- a/components/cache-db/src/main/kotlin/org/veupathdb/vdi/lib/db/cache/sql/select/select-dataset-shares-list.kt
+++ b/components/cache-db/src/main/kotlin/org/veupathdb/vdi/lib/db/cache/sql/select/select-dataset-shares-list.kt
@@ -14,15 +14,12 @@ SELECT
 , dso.recipient_id
 , dso.status AS offer_status
 , dsr.status AS receipt_status
-, ds.
 FROM
   unnest(?) AS ids(dataset_id)
   INNER JOIN vdi.dataset_share_offers AS dso
     USING (dataset_id)
   LEFT JOIN vdi.dataset_share_receipts AS dsr
     USING (dataset_id, recipient_id)
-  LEFT JOIN vdi.datasets AS ds
-    USING (dataset_id)
 """
 
 internal fun Connection.selectSharesFor(datasetIDs: List<DatasetID>): Map<DatasetID, List<DatasetShare>> {

--- a/components/metrics/src/main/kotlin/vdi/component/metrics/Metrics.kt
+++ b/components/metrics/src/main/kotlin/vdi/component/metrics/Metrics.kt
@@ -176,4 +176,31 @@ object Metrics {
     .name("dataset_upload_queue_size")
     .help("Number of dataset uploads currently queued to be processed.")
     .register()
+
+  val importQueueSize: Gauge = Gauge.build()
+    .name("import_queue_size")
+    .help("Number of imports currently queued to be processed.")
+    .register()
+
+  val installQueueSize: Gauge = Gauge.build()
+    .name("install_queue_size")
+    .help("Number of installs currently queued to be processed.")
+    .register()
+
+  val shareQueueSize: Gauge = Gauge.build()
+    .name("share_queue_size")
+    .help("Number of shares currently queued to be processed.")
+    .register()
+
+  val updateMetaQueueSize: Gauge = Gauge.build()
+    .name("update_meta_queue_size")
+    .help("Number of meta updates currently queued to be processed.")
+    .register()
+
+  val softDeleteQueueSize: Gauge = Gauge.build()
+    .name("soft_delete_queue_size")
+    .help("Number of soft deletes currently queued to be processed.")
+    .register()
+
+
 }

--- a/modules/import-trigger-handler/src/main/kotlin/vdi/module/handler/imports/triggers/ImportTriggerHandlerImpl.kt
+++ b/modules/import-trigger-handler/src/main/kotlin/vdi/module/handler/imports/triggers/ImportTriggerHandlerImpl.kt
@@ -56,7 +56,9 @@ internal class ImportTriggerHandlerImpl(private val config: ImportTriggerHandler
 
     val dm = DatasetManager(requireS3Bucket(requireS3Client(config.s3Config), config.s3Bucket))
     val kc = requireKafkaConsumer(config.kafkaConfig.importTriggerTopic, config.kafkaConfig.consumerConfig)
-    val wp = WorkerPool("import-trigger-workers", config.workQueueSize.toInt(), config.workerPoolSize.toInt())
+    val wp = WorkerPool("import-trigger-workers", config.workQueueSize.toInt(), config.workerPoolSize.toInt()) {
+      Metrics.importQueueSize.inc(it.toDouble())
+    }
 
     runBlocking(Dispatchers.IO) {
       launch {

--- a/modules/install-trigger-handler/src/main/kotlin/vdi/module/handler/install/data/InstallDataTriggerHandlerImpl.kt
+++ b/modules/install-trigger-handler/src/main/kotlin/vdi/module/handler/install/data/InstallDataTriggerHandlerImpl.kt
@@ -41,7 +41,9 @@ internal class InstallDataTriggerHandlerImpl(private val config: InstallTriggerH
   override suspend fun run() {
     val kc = requireKafkaConsumer(config.installDataTriggerTopic, config.kafkaConsumerConfig)
     val dm = DatasetManager(requireS3Bucket(requireS3Client(config.s3Config), config.s3Bucket))
-    val wp = WorkerPool("install-data-workers", config.jobQueueSize.toInt(), config.workerPoolSize.toInt())
+    val wp = WorkerPool("install-data-workers", config.jobQueueSize.toInt(), config.workerPoolSize.toInt()) {
+      Metrics.installQueueSize.inc(it.toDouble())
+    }
 
     runBlocking {
       launch(Dispatchers.IO) {

--- a/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/service/datasets/list-datasets.kt
+++ b/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/service/datasets/list-datasets.kt
@@ -14,6 +14,7 @@ import org.veupathdb.vdi.lib.db.app.AppDB
 import org.veupathdb.vdi.lib.db.app.model.InstallStatuses
 import org.veupathdb.vdi.lib.db.cache.CacheDB
 import org.veupathdb.vdi.lib.db.cache.model.DatasetFileSummary
+import org.veupathdb.vdi.lib.db.cache.model.DatasetImportStatus
 import org.veupathdb.vdi.lib.db.cache.model.DatasetListQuery
 import org.veupathdb.vdi.lib.db.cache.model.DatasetRecord
 import org.veupathdb.vdi.lib.handler.mapping.PluginHandlers
@@ -50,6 +51,7 @@ private fun fetchDatasetList(datasetList: List<DatasetRecord>): List<DatasetList
 
   // for each dataset the original search returned
   datasetList.forEach { ds ->
+
     // add the owner id to the set of user ids
     userIDs.add(ds.ownerID)
 
@@ -121,7 +123,10 @@ private fun DatasetRecord.toListEntry(
   out.status        = DatasetStatusInfo(importStatus, statuses)
   out.origin        = origin
   out.sourceUrl     = sourceURL
-  out.shares        = shares
+  if (importStatus !== DatasetImportStatus.Invalid && importStatus !== DatasetImportStatus.Failed) {
+    // Don't set shares if import status is failed since dataset will never be usable by others.
+    out.shares = shares
+  }
   out.fileCount     = fileSummary.count.toInt()
   out.fileSizeTotal = fileSummary.size.toLong()
   out.created       = created.defaultZone()

--- a/modules/share-trigger-handler/build.gradle.kts
+++ b/modules/share-trigger-handler/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
   implementation(project(":components:plugin-mapping"))
   implementation(project(":components:module-core"))
   implementation(project(":components:s3"))
+  implementation(project(":components:metrics"))
 
   implementation("org.veupathdb.vdi:vdi-component-json")
   implementation("org.veupathdb.vdi:vdi-component-common")

--- a/modules/soft-delete-trigger-handler/src/main/kotlin/vdi/module/handler/delete/soft/SoftDeleteTriggerHandlerImpl.kt
+++ b/modules/soft-delete-trigger-handler/src/main/kotlin/vdi/module/handler/delete/soft/SoftDeleteTriggerHandlerImpl.kt
@@ -32,7 +32,9 @@ internal class SoftDeleteTriggerHandlerImpl(private val config: SoftDeleteTrigge
   override suspend fun run() {
     val kc = requireKafkaConsumer(config.softDeleteTriggerTopic, config.kafkaConsumerConfig)
     val dm = DatasetManager(requireS3Bucket(requireS3Client(config.s3Config), config.s3Bucket))
-    val wp = WorkerPool("soft-delete-workers", config.workQueueSize.toInt(), config.workerPoolSize.toInt())
+    val wp = WorkerPool("soft-delete-workers", config.workQueueSize.toInt(), config.workerPoolSize.toInt()) {
+      Metrics.softDeleteQueueSize.inc(it.toDouble())
+    }
 
     runBlocking {
       launch(Dispatchers.IO) {

--- a/modules/update-meta-trigger-handler/src/main/kotlin/vdi/module/handler/meta/triggers/UpdateMetaTriggerHandlerImpl.kt
+++ b/modules/update-meta-trigger-handler/src/main/kotlin/vdi/module/handler/meta/triggers/UpdateMetaTriggerHandlerImpl.kt
@@ -51,7 +51,9 @@ internal class UpdateMetaTriggerHandlerImpl(private val config: UpdateMetaTrigge
     val dm = DatasetManager(requireS3Bucket(requireS3Client(config.s3Config), config.s3Bucket))
     val kc = requireKafkaConsumer(config.kafkaRouterConfig.updateMetaTriggerTopic, config.kafkaConsumerConfig)
     val kr = requireKafkaRouter()
-    val wp = WorkerPool("update-meta-workers", config.workQueueSize.toInt(), config.workerPoolSize.toInt())
+    val wp = WorkerPool("update-meta-workers", config.workQueueSize.toInt(), config.workerPoolSize.toInt()) {
+      Metrics.updateMetaQueueSize.inc(it.toDouble())
+    }
 
     runBlocking(Dispatchers.IO) {
       launch {

--- a/platform/build.gradle.kts
+++ b/platform/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
     api("org.veupathdb.lib:multipart-jackson-pojo:1.1.3")
 
     // VDI
-    api("org.veupathdb.vdi:vdi-component-common:6.7.0")
+    api("org.veupathdb.vdi:vdi-component-common:6.7.1")
     api("org.veupathdb.vdi:vdi-component-json:1.0.1")
 
     // Database


### PR DESCRIPTION
Add metrics for WorkerPool queues.

Don't show shares for failed import datasets.