### PR TITLE
Use latest container core and adapt authenticated annotations

### DIFF
--- a/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/server/controllers/VDIDatasetByIDEndpointsController.kt
+++ b/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/server/controllers/VDIDatasetByIDEndpointsController.kt
@@ -3,15 +3,16 @@ package org.veupathdb.service.vdi.server.controllers
 import jakarta.ws.rs.core.Context
 import org.glassfish.jersey.server.ContainerRequest
 import org.veupathdb.lib.container.jaxrs.server.annotations.Authenticated
+import org.veupathdb.lib.container.jaxrs.server.annotations.Authenticated.AdminOverrideOption.*
 import org.veupathdb.service.vdi.generated.model.DatasetPatchRequest
 import org.veupathdb.service.vdi.generated.resources.VdiDatasetsVdId
 import org.veupathdb.service.vdi.service.datasets.*
 import org.veupathdb.vdi.lib.common.field.toUserID
 
-@Authenticated(allowGuests = false)
+@Authenticated
 class VDIDatasetByIDEndpointsController(@Context request: ContainerRequest) : VdiDatasetsVdId, ControllerBase(request) {
 
-  @Authenticated(allowGuests = false, adminOverride = Authenticated.AdminOverrideOption.ALLOW_ALWAYS)
+  @Authenticated(adminOverride = ALLOW_ALWAYS)
   override fun getVdiDatasetsByVdId(vdID: String): VdiDatasetsVdId.GetVdiDatasetsByVdIdResponse {
     val userID = maybeUserID
       ?: return VdiDatasetsVdId.GetVdiDatasetsByVdIdResponse
@@ -26,7 +27,7 @@ class VDIDatasetByIDEndpointsController(@Context request: ContainerRequest) : Vd
     return VdiDatasetsVdId.PatchVdiDatasetsByVdIdResponse.respond204()
   }
 
-  @Authenticated(allowGuests = false, adminOverride = Authenticated.AdminOverrideOption.ALLOW_ALWAYS)
+  @Authenticated(adminOverride = ALLOW_ALWAYS)
   override fun deleteVdiDatasetsByVdId(vdID: String): VdiDatasetsVdId.DeleteVdiDatasetsByVdIdResponse {
     if (maybeUserID == null)
       adminDeleteDataset(vdID.asVDIID())

--- a/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/server/controllers/VDIDatasetByIDEndpointsController.kt
+++ b/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/server/controllers/VDIDatasetByIDEndpointsController.kt
@@ -2,7 +2,6 @@ package org.veupathdb.service.vdi.server.controllers
 
 import jakarta.ws.rs.core.Context
 import org.glassfish.jersey.server.ContainerRequest
-import org.veupathdb.lib.container.jaxrs.server.annotations.AllowAdminAuth
 import org.veupathdb.lib.container.jaxrs.server.annotations.Authenticated
 import org.veupathdb.service.vdi.generated.model.DatasetPatchRequest
 import org.veupathdb.service.vdi.generated.resources.VdiDatasetsVdId
@@ -12,7 +11,7 @@ import org.veupathdb.vdi.lib.common.field.toUserID
 @Authenticated(allowGuests = false)
 class VDIDatasetByIDEndpointsController(@Context request: ContainerRequest) : VdiDatasetsVdId, ControllerBase(request) {
 
-  @AllowAdminAuth
+  @Authenticated(allowGuests = false, adminOverride = Authenticated.AdminOverrideOption.ALLOW_ALWAYS)
   override fun getVdiDatasetsByVdId(vdID: String): VdiDatasetsVdId.GetVdiDatasetsByVdIdResponse {
     val userID = maybeUserID
       ?: return VdiDatasetsVdId.GetVdiDatasetsByVdIdResponse
@@ -27,7 +26,7 @@ class VDIDatasetByIDEndpointsController(@Context request: ContainerRequest) : Vd
     return VdiDatasetsVdId.PatchVdiDatasetsByVdIdResponse.respond204()
   }
 
-  @AllowAdminAuth
+  @Authenticated(allowGuests = false, adminOverride = Authenticated.AdminOverrideOption.ALLOW_ALWAYS)
   override fun deleteVdiDatasetsByVdId(vdID: String): VdiDatasetsVdId.DeleteVdiDatasetsByVdIdResponse {
     if (maybeUserID == null)
       adminDeleteDataset(vdID.asVDIID())

--- a/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/server/controllers/VDIDatasetFilesController.kt
+++ b/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/server/controllers/VDIDatasetFilesController.kt
@@ -3,17 +3,15 @@ package org.veupathdb.service.vdi.server.controllers
 import jakarta.ws.rs.NotFoundException
 import jakarta.ws.rs.core.Context
 import org.glassfish.jersey.server.ContainerRequest
-import org.veupathdb.lib.container.jaxrs.server.annotations.AllowAdminAuth
 import org.veupathdb.lib.container.jaxrs.server.annotations.Authenticated
 import org.veupathdb.service.vdi.generated.resources.VdiDatasetsVdIdFiles
 import org.veupathdb.service.vdi.service.datasets.*
 import org.veupathdb.vdi.lib.common.field.toDatasetIDOrNull
 import org.veupathdb.vdi.lib.common.field.toUserID
 
-@Authenticated(allowGuests = false)
+@Authenticated(allowGuests = false, adminOverride = Authenticated.AdminOverrideOption.ALLOW_ALWAYS)
 class VDIDatasetFilesController(@Context request: ContainerRequest) : VdiDatasetsVdIdFiles, ControllerBase(request) {
 
-  @AllowAdminAuth
   override fun getVdiDatasetsFilesByVdId(vdId: String): VdiDatasetsVdIdFiles.GetVdiDatasetsFilesByVdIdResponse {
     val datasetID = vdId.toDatasetIDOrNull() ?: throw NotFoundException()
 
@@ -26,7 +24,6 @@ class VDIDatasetFilesController(@Context request: ContainerRequest) : VdiDataset
     )
   }
 
-  @AllowAdminAuth
   override fun getVdiDatasetsFilesUploadByVdId(vdId: String): VdiDatasetsVdIdFiles.GetVdiDatasetsFilesUploadByVdIdResponse {
     val datasetID = vdId.toDatasetIDOrNull() ?: throw NotFoundException()
 
@@ -45,7 +42,6 @@ class VDIDatasetFilesController(@Context request: ContainerRequest) : VdiDataset
       )
   }
 
-  @AllowAdminAuth
   override fun getVdiDatasetsFilesDataByVdId(vdId: String): VdiDatasetsVdIdFiles.GetVdiDatasetsFilesDataByVdIdResponse {
     val datasetID = vdId.toDatasetIDOrNull() ?: throw NotFoundException()
 

--- a/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/server/controllers/VDIDatasetFilesController.kt
+++ b/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/server/controllers/VDIDatasetFilesController.kt
@@ -4,12 +4,13 @@ import jakarta.ws.rs.NotFoundException
 import jakarta.ws.rs.core.Context
 import org.glassfish.jersey.server.ContainerRequest
 import org.veupathdb.lib.container.jaxrs.server.annotations.Authenticated
+import org.veupathdb.lib.container.jaxrs.server.annotations.Authenticated.AdminOverrideOption.*
 import org.veupathdb.service.vdi.generated.resources.VdiDatasetsVdIdFiles
 import org.veupathdb.service.vdi.service.datasets.*
 import org.veupathdb.vdi.lib.common.field.toDatasetIDOrNull
 import org.veupathdb.vdi.lib.common.field.toUserID
 
-@Authenticated(allowGuests = false, adminOverride = Authenticated.AdminOverrideOption.ALLOW_ALWAYS)
+@Authenticated(adminOverride = ALLOW_ALWAYS)
 class VDIDatasetFilesController(@Context request: ContainerRequest) : VdiDatasetsVdIdFiles, ControllerBase(request) {
 
   override fun getVdiDatasetsFilesByVdId(vdId: String): VdiDatasetsVdIdFiles.GetVdiDatasetsFilesByVdIdResponse {

--- a/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/server/controllers/VDIDatasetSharePutController.kt
+++ b/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/server/controllers/VDIDatasetSharePutController.kt
@@ -3,7 +3,6 @@ package org.veupathdb.service.vdi.server.controllers
 import jakarta.ws.rs.*
 import jakarta.ws.rs.core.Context
 import org.glassfish.jersey.server.ContainerRequest
-import org.veupathdb.lib.container.jaxrs.server.annotations.AllowAdminAuth
 import org.veupathdb.lib.container.jaxrs.server.annotations.Authenticated
 import org.veupathdb.service.vdi.generated.model.DatasetShareOffer
 import org.veupathdb.service.vdi.generated.model.DatasetShareReceipt
@@ -22,7 +21,7 @@ class VDIDatasetSharePutController(@Context request: ContainerRequest) : VdiData
   @Path("/offer")
   @Produces("application/json")
   @Consumes("application/json")
-  @AllowAdminAuth
+  @Authenticated(allowGuests = false, adminOverride = Authenticated.AdminOverrideOption.ALLOW_ALWAYS)
   override fun putVdiDatasetsSharesOfferByVdIdAndRecipientUserId(
     @PathParam("vd-id") vdId: String,
     @PathParam("recipient-user-id") recipientUserId: Long,
@@ -46,7 +45,7 @@ class VDIDatasetSharePutController(@Context request: ContainerRequest) : VdiData
   @Path("/receipt")
   @Produces("application/json")
   @Consumes("application/json")
-  @AllowAdminAuth
+  @Authenticated(allowGuests = false, adminOverride = Authenticated.AdminOverrideOption.ALLOW_ALWAYS)
   override fun putVdiDatasetsSharesReceiptByVdIdAndRecipientUserId(
     @PathParam("vd-id") vdId: String,
     @PathParam("recipient-user-id") recipientUserId: Long,

--- a/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/server/controllers/VDIDatasetSharePutController.kt
+++ b/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/server/controllers/VDIDatasetSharePutController.kt
@@ -4,6 +4,7 @@ import jakarta.ws.rs.*
 import jakarta.ws.rs.core.Context
 import org.glassfish.jersey.server.ContainerRequest
 import org.veupathdb.lib.container.jaxrs.server.annotations.Authenticated
+import org.veupathdb.lib.container.jaxrs.server.annotations.Authenticated.AdminOverrideOption.ALLOW_ALWAYS
 import org.veupathdb.service.vdi.generated.model.DatasetShareOffer
 import org.veupathdb.service.vdi.generated.model.DatasetShareReceipt
 import org.veupathdb.service.vdi.generated.resources.VdiDatasetsVdIdSharesRecipientUserId
@@ -13,7 +14,7 @@ import org.veupathdb.service.vdi.service.shares.putShareReceipt
 import org.veupathdb.vdi.lib.common.field.UserID
 import org.veupathdb.vdi.lib.common.field.toUserID
 
-@Authenticated(allowGuests = false)
+@Authenticated
 @Path("/vdi-datasets/{vd-id}/shares/{recipient-user-id}")
 class VDIDatasetSharePutController(@Context request: ContainerRequest) : VdiDatasetsVdIdSharesRecipientUserId, ControllerBase(request) {
 
@@ -21,7 +22,7 @@ class VDIDatasetSharePutController(@Context request: ContainerRequest) : VdiData
   @Path("/offer")
   @Produces("application/json")
   @Consumes("application/json")
-  @Authenticated(allowGuests = false, adminOverride = Authenticated.AdminOverrideOption.ALLOW_ALWAYS)
+  @Authenticated(adminOverride = ALLOW_ALWAYS)
   override fun putVdiDatasetsSharesOfferByVdIdAndRecipientUserId(
     @PathParam("vd-id") vdId: String,
     @PathParam("recipient-user-id") recipientUserId: Long,
@@ -45,7 +46,7 @@ class VDIDatasetSharePutController(@Context request: ContainerRequest) : VdiData
   @Path("/receipt")
   @Produces("application/json")
   @Consumes("application/json")
-  @Authenticated(allowGuests = false, adminOverride = Authenticated.AdminOverrideOption.ALLOW_ALWAYS)
+  @Authenticated(adminOverride = ALLOW_ALWAYS)
   override fun putVdiDatasetsSharesReceiptByVdIdAndRecipientUserId(
     @PathParam("vd-id") vdId: String,
     @PathParam("recipient-user-id") recipientUserId: Long,

--- a/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/server/controllers/VDIDatasetsAdminController.kt
+++ b/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/server/controllers/VDIDatasetsAdminController.kt
@@ -4,6 +4,7 @@ import jakarta.ws.rs.BadRequestException
 import jakarta.ws.rs.ForbiddenException
 import org.veupathdb.lib.container.jaxrs.server.annotations.AdminRequired
 import org.veupathdb.lib.container.jaxrs.server.annotations.Authenticated
+import org.veupathdb.lib.container.jaxrs.server.annotations.Authenticated.AdminOverrideOption.*
 import org.veupathdb.service.vdi.db.UserDB
 import org.veupathdb.service.vdi.generated.model.*
 import org.veupathdb.service.vdi.generated.resources.VdiDatasetsAdmin
@@ -29,7 +30,7 @@ private const val biQueryLimitDefault = 100
 private const val biQueryOffsetMinimum = 0
 private const val biQueryOffsetDefault = 0
 
-@Authenticated(adminOverride = Authenticated.AdminOverrideOption.ALLOW_ALWAYS)
+@Authenticated(adminOverride = ALLOW_ALWAYS)
 @AdminRequired
 class VDIDatasetsAdminController : VdiDatasetsAdmin {
 

--- a/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/server/controllers/VDIDatasetsAdminController.kt
+++ b/modules/rest-service/src/main/kotlin/org/veupathdb/service/vdi/server/controllers/VDIDatasetsAdminController.kt
@@ -2,7 +2,7 @@ package org.veupathdb.service.vdi.server.controllers
 
 import jakarta.ws.rs.BadRequestException
 import jakarta.ws.rs.ForbiddenException
-import org.veupathdb.lib.container.jaxrs.server.annotations.AllowAdminAuth
+import org.veupathdb.lib.container.jaxrs.server.annotations.AdminRequired
 import org.veupathdb.lib.container.jaxrs.server.annotations.Authenticated
 import org.veupathdb.service.vdi.db.UserDB
 import org.veupathdb.service.vdi.generated.model.*
@@ -29,8 +29,8 @@ private const val biQueryLimitDefault = 100
 private const val biQueryOffsetMinimum = 0
 private const val biQueryOffsetDefault = 0
 
-@Authenticated
-@AllowAdminAuth(required = true)
+@Authenticated(adminOverride = Authenticated.AdminOverrideOption.ALLOW_ALWAYS)
+@AdminRequired
 class VDIDatasetsAdminController : VdiDatasetsAdmin {
 
   override fun getVdiDatasetsAdminListBroken(

--- a/platform/build.gradle.kts
+++ b/platform/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 dependencies {
   constraints {
     api("org.gusdb:fgputil-db:2.12.11")
-    api("org.veupathdb.lib:jaxrs-container-core:6.20.1")
+    api("org.veupathdb.lib:jaxrs-container-core:6.21.1")
     api("org.veupathdb.lib:multipart-jackson-pojo:1.1.3")
 
     // VDI


### PR DESCRIPTION
## Overview
* Use latest container core
* Fix annotations based on compatibility changes

1. Posted to `https://vdi-dev.local.apidb.org:8443/vdi-datasets` with my auth token
2. GET to `https://vdi-dev.local.apidb.org:8443/vdi-datasets/crjmaoxMfho` with admin token - Received 200
2. GET to `https://vdi-dev.local.apidb.org:8443/vdi-datasets/crjmaoxMfho` without admin token - Received 403
3. GET to `https://vdi-dev.local.apidb.org:8443/vdi-datasets/admin/failed-imports` with admin token - Received 200
4. GET to `https://vdi-dev.local.apidb.org:8443/vdi-datasets/admin/failed-imports` without admin token - Received 403