### PR TITLE
use latest container core

### DIFF
--- a/platform/build.gradle.kts
+++ b/platform/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 dependencies {
   constraints {
     api("org.gusdb:fgputil-db:2.12.11")
-    api("org.veupathdb.lib:jaxrs-container-core:6.21.1")
+    api("org.veupathdb.lib:jaxrs-container-core:6.21.3")
     api("org.veupathdb.lib:multipart-jackson-pojo:1.1.3")
 
     // VDI


### PR DESCRIPTION
Using container-core with new multi-part file pojo library that uses buffered file output stream.