### PR TITLE
Reconciliation Process Patches

### DIFF
--- a/components/cache-db/src/main/kotlin/org/veupathdb/vdi/lib/db/cache/CacheDBTransactionImpl.kt
+++ b/components/cache-db/src/main/kotlin/org/veupathdb/vdi/lib/db/cache/CacheDBTransactionImpl.kt
@@ -179,7 +179,7 @@ internal class CacheDBTransactionImpl(private val connection: Connection) : Cach
   }
 
   override fun upsertImportControl(datasetID: DatasetID, status: DatasetImportStatus) {
-    log.debug("upserting share import control record for dataset {} for status {}", datasetID, status)
+    log.debug("upserting import control record for dataset {} for status {}", datasetID, status)
     con.upsertImportControl(datasetID, status)
   }
 

--- a/modules/reconciler/src/main/kotlin/org/veupathdb/vdi/lib/reconciler/ReconcilerInstance.kt
+++ b/modules/reconciler/src/main/kotlin/org/veupathdb/vdi/lib/reconciler/ReconcilerInstance.kt
@@ -13,6 +13,21 @@ import org.veupathdb.vdi.lib.s3.datasets.DatasetManager
 import vdi.component.metrics.Metrics
 import java.time.OffsetDateTime
 
+private enum class Reason {
+  MissingInTargetDB {
+    override fun toString() = "missing in target database"
+  },
+  MissingInSource {
+    override fun toString() = "missing in data store"
+  },
+  OutOfSync {
+    override fun toString() = "out of sync"
+  },
+  NeedsUninstallation {
+    override fun toString() = "needs uninstallation"
+  }
+}
+
 /**
  * Component for synchronizing the dataset object store (the source of truth for datasets) with a target database.
  *
@@ -96,18 +111,18 @@ class ReconcilerInstance(
         if (comparableS3Id.compareTo(comparableTargetId, false) < 0) {
           // Dataset is in source, but not in target. Send an event.
           Metrics.missingInTarget.labels(targetDB.name).inc()
-          sendSyncIfRelevant(sourceDatasetDir)
+          sendSyncIfRelevant(sourceDatasetDir, Reason.MissingInTargetDB)
         } else {
 
           // If dataset has a delete flag present and the dataset is not marked
           // as uninstalled from the target, then send a sync event.
           if (sourceDatasetDir.hasDeleteFlag() && !nextTargetDataset!!.isUninstalled) {
-            sendSyncEvent(nextTargetDataset!!.ownerID, nextTargetDataset!!.datasetID)
+            sendSyncEvent(nextTargetDataset!!.ownerID, nextTargetDataset!!.datasetID, Reason.NeedsUninstallation)
           }
 
           // Dataset is in source and target. Check dates to see if sync is needed.
           else if (isOutOfSync(sourceDatasetDir, nextTargetDataset!!)) {
-            sendSyncIfRelevant(sourceDatasetDir)
+            sendSyncIfRelevant(sourceDatasetDir, Reason.OutOfSync)
           }
 
           // Advance next target dataset pointer, we're done with this one since it's in sync.
@@ -170,7 +185,7 @@ class ReconcilerInstance(
     return shareOos || dataOos || metaOos
   }
 
-  private fun sendSyncIfRelevant(sourceDatasetDir: DatasetDirectory) {
+  private fun sendSyncIfRelevant(sourceDatasetDir: DatasetDirectory, reason: Reason) {
     if (targetDB.type == ReconcilerTargetType.Install) {
       val relevantProjects = sourceDatasetDir.getMetaFile().load()!!.projects
       if (!relevantProjects.contains(targetDB.name)) {
@@ -179,11 +194,11 @@ class ReconcilerInstance(
       }
     }
 
-    sendSyncEvent(sourceDatasetDir.ownerID, sourceDatasetDir.datasetID)
+    sendSyncEvent(sourceDatasetDir.ownerID, sourceDatasetDir.datasetID, reason)
   }
 
-  private fun sendSyncEvent(ownerID: UserID, datasetID: DatasetID) {
-    logger().info("sending reconciliation event for $ownerID/$datasetID")
+  private fun sendSyncEvent(ownerID: UserID, datasetID: DatasetID, reason: Reason) {
+    logger().info("sending reconciliation event for $ownerID/$datasetID for reason: $reason")
     kafkaRouter.sendReconciliationTrigger(ownerID, datasetID)
     Metrics.reconcilerDatasetSynced.labels(targetDB.name).inc()
   }
@@ -192,9 +207,9 @@ class ReconcilerInstance(
     sourceIterator: Iterator<DatasetDirectory>,
     sourceDatasetDir: DatasetDirectory
   ) {
-    sendSyncIfRelevant(sourceDatasetDir)
+    sendSyncIfRelevant(sourceDatasetDir, Reason.MissingInTargetDB)
     while (sourceIterator.hasNext()) {
-      sendSyncIfRelevant(sourceIterator.next())
+      sendSyncIfRelevant(sourceIterator.next(), Reason.MissingInTargetDB)
     }
   }
 }

--- a/modules/reconciliation-event-handler/build.gradle.kts
+++ b/modules/reconciliation-event-handler/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -36,7 +37,4 @@ tasks.withType<KotlinCompile>().configureEach {
   kotlinOptions {
     freeCompilerArgs = freeCompilerArgs + "-Xcontext-receivers"
   }
-}
-tasks.test {
-  useJUnitPlatform()
 }

--- a/modules/reconciliation-event-handler/src/test/kotlin/vdi/lane/reconciliation/DatasetReconcilerTest.kt
+++ b/modules/reconciliation-event-handler/src/test/kotlin/vdi/lane/reconciliation/DatasetReconcilerTest.kt
@@ -398,8 +398,8 @@ class DatasetReconcilerTest {
 
           DatasetReconciler(cacheDB, mockAppDB(), router, dsMan).reconcile(userID, datasetID)
 
-          verify(cacheDB, times(2)).selectImportControl(datasetID)
-          verify(cacheDB, times(2)).selectImportMessages(datasetID)
+          verify(cacheDB, times(1)).selectImportControl(datasetID)
+          verify(cacheDB, times(1)).selectImportMessages(datasetID)
           verify(transaction, times(1)).upsertImportControl(datasetID, DatasetImportStatus.Queued)
           verify(router, times(1)).sendImportTrigger(userID, datasetID)
           verifyNoMoreInteractions(router)
@@ -434,8 +434,8 @@ class DatasetReconcilerTest {
           DatasetReconciler(cacheDB, appDB, router, dsMan).reconcile(userID, datasetID)
 
           // Called in tryInitCacheDB and main reconciliation path
-          verify(cacheDB, times(2)).selectImportControl(datasetID)
-          verify(cacheDB, times(2)).selectImportMessages(datasetID)
+          verify(cacheDB, times(1)).selectImportControl(datasetID)
+          verify(cacheDB, times(1)).selectImportMessages(datasetID)
 
           verifyNoInteractions(appDB)
           verifyNoInteractions(router)


### PR DESCRIPTION
Sifting through the VDI logs I noticed that a reconciliation event for the dataset was being repeatedly fired by the reconciler and then it was being repeatedly processed by the reconciliation event handler.  Why the reconciler is firing an event for it is still unclear, but the reconciliation event handler should be ignoring it.

This PR addresses the above by:

1. Patch bug in dataset reconciler where dataset imports would be refired if the dataset import status was Invalid
2. Add additional logging to the reconciler to include the reason it is firing a sync event in the logs