### PR TITLE
Fix exceptions on startup due to double locking on a mutex.

### DIFF
--- a/lib/async/src/main/kotlin/vdi/component/async/Trigger.kt
+++ b/lib/async/src/main/kotlin/vdi/component/async/Trigger.kt
@@ -13,14 +13,14 @@ class Trigger {
   private var triggered = false
 
   suspend fun trigger() {
-    mutex.withLock(this) { triggered = true }
+    mutex.withLock { triggered = true }
     tryRelease()
   }
 
-  suspend fun isTriggered() = mutex.withLock(this) { triggered }
+  suspend fun isTriggered() = mutex.withLock { triggered }
 
   suspend fun await() {
-    mutex.withLock(this) {
+    mutex.withLock {
       if (triggered)
         return release()
     }
@@ -33,7 +33,7 @@ class Trigger {
   }
 
   private suspend fun tryRelease() {
-    mutex.withLock(this) {
+    mutex.withLock {
       if (triggered)
         release()
     }


### PR DESCRIPTION
The issue wasn't actually a problem with the process, it was a misunderstanding of a debug feature that causes exceptions to be thrown under normal circumstances.