### PR TITLE
put delete flag in minio before postgres

### DIFF
--- a/service/rest-service/src/main/kotlin/org/veupathdb/service/vdi/service/datasets/delete-dataset-by-id.kt
+++ b/service/rest-service/src/main/kotlin/org/veupathdb/service/vdi/service/datasets/delete-dataset-by-id.kt
@@ -38,10 +38,10 @@ internal fun userDeleteDataset(userID: UserID, datasetID: DatasetID) {
 
 private fun deleteUserDataset(userID: UserID, datasetID: DatasetID) {
   vdi.component.db.cache.CacheDB().withTransaction {
-    // Update the deleted flag in the local pg.
-    it.updateDatasetDeleted(datasetID, true)
-
     // Put a delete flag in S3 for the target dataset.
     DatasetStore.putDeleteFlag(userID, datasetID)
+
+    // Update the deleted flag in the local pg.
+    it.updateDatasetDeleted(datasetID, true)
   }
 }


### PR DESCRIPTION
To avoid leaving a dataset in a weird state where it isn't visible to the user but is never actually uninstalled.