### PR TITLE
use 2 timestamps to derive the 2 deltas

### DIFF
--- a/service/daemon/reconciler/src/main/kotlin/vdi/daemon/reconciler/ReconcilerImpl.kt
+++ b/service/daemon/reconciler/src/main/kotlin/vdi/daemon/reconciler/ReconcilerImpl.kt
@@ -27,7 +27,9 @@ internal class ReconcilerImpl(private val config: ReconcilerConfig, abortCB: Abo
 
   private val targets: List<ReconcilerTarget>
 
-  private var lastRun = 0L
+  private var lastSlimRun = 0L
+
+  private var lastFullRun = 0L
 
   private val cacheDBTarget: ReconcilerTarget
 
@@ -51,16 +53,18 @@ internal class ReconcilerImpl(private val config: ReconcilerConfig, abortCB: Abo
   override suspend fun runJob() {
     val now = System.currentTimeMillis()
 
-    val delta = (now - lastRun).milliseconds
-
     when {
-      config.reconcilerEnabled && delta >= config.fullRunInterval -> {
-        lastRun = now
+      // delta between last full run and now is greater than or equal to the
+      // full reconciler run interval
+      (now - lastFullRun).milliseconds >= config.fullRunInterval -> {
+        lastFullRun = now
         runFull()
       }
 
-      delta >= config.slimRunInterval -> {
-        lastRun = now
+      // delta between last slim run and now is greater than or equal to the
+      // slim reconciler run interval
+      (now - lastSlimRun).milliseconds >= config.slimRunInterval -> {
+        lastSlimRun = now
         runSlim()
       }
     }


### PR DESCRIPTION
The `lastRun` variable was being updated every 5 minutes by the slim reconciler run, meaning the delta would never grow large enough to trigger the full reconciler run.

Closes #320