### PR TITLE
Stop using jersey's jackson filter instead of ours.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,11 +3,11 @@
 # VPDB
 fgputil-db = { group = "org.gusdb", name = "fgputil-db", version = "2.16.0-jakarta" }
 
-container-core      = { group = "org.veupathdb.lib", name = "jaxrs-container-core",   version = "9.1.1" }
+container-core      = { group = "org.veupathdb.lib", name = "jaxrs-container-core",   version = "9.1.3" }
 container-multipart = { group = "org.veupathdb.lib", name = "multipart-jackson-pojo", version = "1.1.7" }
 
-vdi-common = { group = "org.veupathdb.vdi", name = "vdi-component-common", version = "17.1.5" }
-vdi-json   = { group = "org.veupathdb.vdi", name = "vdi-component-json",   version = "1.0.2"  }
+vdi-common = { group = "org.veupathdb.vdi", name = "vdi-component-common", version = "17.1.6" }
+vdi-json   = { group = "org.veupathdb.vdi", name = "vdi-component-json",   version = "1.0.3"  }
 
 # Database
 db-pool            = { group = "com.zaxxer",               name = "HikariCP",   version = "6.2.1"        }


### PR DESCRIPTION
* container-core: removal of unused and problematic jersey lib to fix json (de)serialization issues.
* vdi-json: jackson version update
* vdi-component-common: 2 types were missing explicit type delegation that unconfigured jackson couldn't find, but all other types have explicit definitions so I added the missing 2.
